### PR TITLE
feat(map): add WebGPU viewport culling

### DIFF
--- a/src/components/map/openstreet-map-helpers.tsx
+++ b/src/components/map/openstreet-map-helpers.tsx
@@ -93,6 +93,11 @@ import {
   PaginationPrevious,
 } from "@/components/ui/pagination";
 import type { AppSettings, DataLayerVisibility } from "@/types/settings";
+import {
+  containsViewportBounds,
+  useWebGpuVisibility,
+  type ViewportBounds,
+} from "@/hooks/use-webgpu-visibility";
 
 export type MapViewState = {
   center: [number, number];
@@ -529,7 +534,7 @@ export function GlobalSignalMarkers({
   const { map, isLoaded } = useMap();
   const [viewportState, setViewportState] = React.useState(() => ({
     zoom: 0,
-    bounds: null as maplibregl.LngLatBounds | null,
+    bounds: null as ViewportBounds | null,
   }));
   const [expandedMarkerKey, setExpandedMarkerKey] = React.useState<string | null>(null);
   const collapseTimeoutRef = React.useRef<number | null>(null);
@@ -584,9 +589,15 @@ export function GlobalSignalMarkers({
     if (!map || !isLoaded) return;
 
     const syncViewportState = () => {
+      const bounds = map.getBounds();
       setViewportState({
         zoom: map.getZoom(),
-        bounds: map.getBounds(),
+        bounds: {
+          west: bounds.getWest(),
+          east: bounds.getEast(),
+          south: bounds.getSouth(),
+          north: bounds.getNorth(),
+        },
       });
     };
 
@@ -604,7 +615,23 @@ export function GlobalSignalMarkers({
     (coordinates: [number, number]) => {
       const bounds = viewportState.bounds;
       if (!bounds) return false;
-      return bounds.contains([coordinates[0], coordinates[1]]);
+      return containsViewportBounds(bounds, coordinates);
+    },
+    [viewportState.bounds]
+  );
+
+  const getVisibleItems = React.useCallback(
+    <T extends { id: string; coordinates: [number, number] }>(
+      items: T[],
+      mask: Uint32Array | null | undefined,
+    ) => {
+      if (mask && mask.length === items.length) {
+        return items.filter((_, index) => mask[index] === 1);
+      }
+
+      const bounds = viewportState.bounds;
+      if (!bounds) return [];
+      return items.filter((item) => containsViewportBounds(bounds, item.coordinates));
     },
     [viewportState.bounds]
   );
@@ -613,6 +640,29 @@ export function GlobalSignalMarkers({
   const isDetailMode = viewportState.zoom >= GLOBAL_DETAIL_MIN_ZOOM;
   const shouldRenderGlobalMarkers = isCompactNodeMode || isDetailMode;
   const isBridgeZoomMode = !isCompactNodeMode && !isDetailMode;
+
+  const gpuVisibilityDatasets = React.useMemo(
+    () => ({
+      eonet: layerVisibility.eonet ? events : [],
+      tsunami: layerVisibility.tsunami ? tsunamiAlerts : [],
+      airQuality: layerVisibility.airQuality ? airQualitySites : [],
+    }),
+    [
+      airQualitySites,
+      events,
+      layerVisibility.airQuality,
+      layerVisibility.eonet,
+      layerVisibility.tsunami,
+      tsunamiAlerts,
+    ]
+  );
+
+  const gpuVisibility = useWebGpuVisibility({
+    bounds: viewportState.bounds,
+    datasets: gpuVisibilityDatasets,
+    enabled: shouldRenderGlobalMarkers && !isBridgeZoomMode,
+    threshold: 180,
+  });
 
   const withSelectedPriority = React.useCallback(
     <T extends { id: string; coordinates: [number, number] }>(
@@ -640,14 +690,15 @@ export function GlobalSignalMarkers({
       return [selectedEvent];
     }
     if (!shouldRenderGlobalMarkers) return [];
-    const base = events
-      .filter((event) => isPointVisible(event.coordinates))
+    const base = getVisibleItems(events, gpuVisibility.masks.eonet)
       .slice(0, MAX_VISIBLE_GLOBAL_MARKERS);
     return withSelectedPriority(base, layerVisibility.eonet ? selectedEvent : null);
   }, [
     events,
     isBridgeZoomMode,
     isPointVisible,
+    getVisibleItems,
+    gpuVisibility.masks.eonet,
     layerVisibility.eonet,
     selectedEvent,
     shouldRenderGlobalMarkers,
@@ -661,8 +712,7 @@ export function GlobalSignalMarkers({
       return [selectedTsunamiAlert];
     }
     if (!shouldRenderGlobalMarkers) return [];
-    const base = tsunamiAlerts
-      .filter((alert) => isPointVisible(alert.coordinates))
+    const base = getVisibleItems(tsunamiAlerts, gpuVisibility.masks.tsunami)
       .slice(0, MAX_VISIBLE_GLOBAL_MARKERS);
     return withSelectedPriority(
       base,
@@ -671,6 +721,8 @@ export function GlobalSignalMarkers({
   }, [
     isBridgeZoomMode,
     isPointVisible,
+    getVisibleItems,
+    gpuVisibility.masks.tsunami,
     layerVisibility.tsunami,
     selectedTsunamiAlert,
     shouldRenderGlobalMarkers,
@@ -685,8 +737,7 @@ export function GlobalSignalMarkers({
       return [selectedAirQualitySite];
     }
     if (!shouldRenderGlobalMarkers) return [];
-    const base = airQualitySites
-      .filter((site) => isPointVisible(site.coordinates))
+    const base = getVisibleItems(airQualitySites, gpuVisibility.masks.airQuality)
       .slice(0, MAX_VISIBLE_GLOBAL_MARKERS);
     return withSelectedPriority(
       base,
@@ -696,6 +747,8 @@ export function GlobalSignalMarkers({
     airQualitySites,
     isBridgeZoomMode,
     isPointVisible,
+    getVisibleItems,
+    gpuVisibility.masks.airQuality,
     layerVisibility.airQuality,
     selectedAirQualitySite,
     shouldRenderGlobalMarkers,

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -3,3 +3,5 @@ export { useWeather, getWeatherIcon } from "./use-weather";
 export { useEonetEvents } from "./use-eonet-events";
 export { useAirQuality } from "./use-air-quality";
 export { useTsunamiAlerts } from "./use-tsunami-alerts";
+export { useWebGpuVisibility, containsViewportBounds } from "./use-webgpu-visibility";
+export type { ViewportBounds } from "./use-webgpu-visibility";

--- a/src/hooks/use-webgpu-visibility.ts
+++ b/src/hooks/use-webgpu-visibility.ts
@@ -1,0 +1,211 @@
+import * as React from "react";
+
+import { isWebGPUAvailable } from "@/lib/webgpu";
+
+export type ViewportBounds = {
+  west: number;
+  east: number;
+  south: number;
+  north: number;
+};
+
+export type ViewportPoint = {
+  coordinates: [number, number];
+};
+
+type VisibilityWorkerRequest = {
+  requestId: number;
+  bounds: ViewportBounds;
+  datasets: Array<{
+    key: string;
+    coordinates: Float32Array;
+  }>;
+};
+
+type VisibilityWorkerResponse = {
+  requestId: number;
+  supported: boolean;
+  datasets: Array<{
+    key: string;
+    visibility: ArrayBuffer;
+  }>;
+};
+
+type UseWebGpuVisibilityArgs = {
+  bounds: ViewportBounds | null;
+  datasets: Record<string, ViewportPoint[]>;
+  enabled?: boolean;
+  threshold?: number;
+};
+
+type UseWebGpuVisibilityState = {
+  isSupported: boolean;
+  isPending: boolean;
+  masks: Record<string, Uint32Array | null>;
+};
+
+export const containsViewportBounds = (
+  bounds: ViewportBounds,
+  coordinates: [number, number],
+) => {
+  const [longitude, latitude] = coordinates;
+  const isLongitudeVisible =
+    bounds.west <= bounds.east
+      ? longitude >= bounds.west && longitude <= bounds.east
+      : longitude >= bounds.west || longitude <= bounds.east;
+  const isLatitudeVisible = latitude >= bounds.south && latitude <= bounds.north;
+
+  return isLongitudeVisible && isLatitudeVisible;
+};
+
+export function useWebGpuVisibility(
+  args: UseWebGpuVisibilityArgs,
+): UseWebGpuVisibilityState {
+  const { bounds, datasets, enabled = true, threshold = 180 } = args;
+  const workerRef = React.useRef<Worker | null>(null);
+  const requestIdRef = React.useRef(0);
+  const [isSupported, setIsSupported] = React.useState(false);
+  const [isPending, setIsPending] = React.useState(false);
+  const [masks, setMasks] = React.useState<Record<string, Uint32Array | null>>({});
+
+  const datasetEntries = React.useMemo(() => Object.entries(datasets), [datasets]);
+  const totalPointCount = React.useMemo(
+    () => datasetEntries.reduce((sum, [, items]) => sum + items.length, 0),
+    [datasetEntries],
+  );
+
+  const shouldUseWebGpu =
+    enabled && Boolean(bounds) && totalPointCount >= threshold && isWebGPUAvailable();
+
+  React.useEffect(() => {
+    if (!shouldUseWebGpu) {
+      setIsSupported(false);
+      setIsPending(false);
+      setMasks({});
+
+      if (workerRef.current) {
+        workerRef.current.terminate();
+        workerRef.current = null;
+      }
+
+      return;
+    }
+
+    if (!workerRef.current) {
+      try {
+        workerRef.current = new Worker(
+          new URL("../workers/webgpu-viewport-culling.worker.ts", import.meta.url),
+          { type: "module" },
+        );
+      } catch {
+        setIsSupported(false);
+        setIsPending(false);
+        setMasks({});
+        return;
+      }
+    }
+
+    const worker = workerRef.current;
+    const handleMessage = (event: MessageEvent<VisibilityWorkerResponse>) => {
+      const payload = event.data;
+      if (payload.requestId !== requestIdRef.current) {
+        return;
+      }
+
+      if (!payload.supported) {
+        setIsSupported(false);
+        setIsPending(false);
+        setMasks({});
+
+        worker.terminate();
+        workerRef.current = null;
+        return;
+      }
+
+      const nextMasks = payload.datasets.reduce<Record<string, Uint32Array | null>>(
+        (accumulator, dataset) => {
+          accumulator[dataset.key] = new Uint32Array(dataset.visibility);
+          return accumulator;
+        },
+        {},
+      );
+
+      setIsSupported(true);
+      setIsPending(false);
+      setMasks(nextMasks);
+    };
+
+    const handleError = () => {
+      setIsSupported(false);
+      setIsPending(false);
+      setMasks({});
+
+      worker.terminate();
+      workerRef.current = null;
+    };
+
+    worker.addEventListener("message", handleMessage);
+    worker.addEventListener("error", handleError);
+
+    const payloadDatasets = datasetEntries
+      .filter(([, items]) => items.length > 0)
+      .map(([key, items]) => {
+        const coordinates = new Float32Array(items.length * 2);
+
+        items.forEach((item, index) => {
+          coordinates[index * 2] = item.coordinates[0];
+          coordinates[index * 2 + 1] = item.coordinates[1];
+        });
+
+        return {
+          key,
+          coordinates,
+        };
+      });
+
+    if (payloadDatasets.length === 0 || !bounds) {
+      setIsSupported(true);
+      setIsPending(false);
+      setMasks({});
+
+      worker.removeEventListener("message", handleMessage);
+      worker.removeEventListener("error", handleError);
+      return;
+    }
+
+    const requestId = requestIdRef.current + 1;
+    requestIdRef.current = requestId;
+    setIsSupported(true);
+    setIsPending(true);
+
+    const requestPayload: VisibilityWorkerRequest = {
+      requestId,
+      bounds,
+      datasets: payloadDatasets,
+    };
+
+    worker.postMessage(
+      requestPayload,
+      payloadDatasets.map((dataset) => dataset.coordinates.buffer),
+    );
+
+    return () => {
+      worker.removeEventListener("message", handleMessage);
+      worker.removeEventListener("error", handleError);
+    };
+  }, [bounds, datasetEntries, enabled, shouldUseWebGpu, threshold, totalPointCount]);
+
+  React.useEffect(() => {
+    return () => {
+      if (!workerRef.current) return;
+      workerRef.current.terminate();
+      workerRef.current = null;
+    };
+  }, []);
+
+  return {
+    isSupported,
+    isPending,
+    masks,
+  };
+}

--- a/src/lib/webgpu.ts
+++ b/src/lib/webgpu.ts
@@ -1,0 +1,12 @@
+export const isWebGPUAvailable = (): boolean => {
+  if (typeof navigator === "undefined") return false;
+
+  return "gpu" in navigator;
+};
+
+export const shouldUseWebGPU = (
+  itemCount: number,
+  threshold = 180,
+): boolean => {
+  return isWebGPUAvailable() && itemCount >= threshold;
+};

--- a/src/workers/webgpu-viewport-culling.worker.ts
+++ b/src/workers/webgpu-viewport-culling.worker.ts
@@ -1,0 +1,339 @@
+/// <reference lib="webworker" />
+
+type ViewportBounds = {
+  west: number;
+  east: number;
+  south: number;
+  north: number;
+};
+
+type VisibilityDatasetPayload = {
+  key: string;
+  coordinates: ArrayBuffer;
+};
+
+type VisibilityRequestPayload = {
+  requestId: number;
+  bounds: ViewportBounds;
+  datasets: VisibilityDatasetPayload[];
+};
+
+type VisibilityDatasetResponse = {
+  key: string;
+  visibility: ArrayBuffer;
+};
+
+type VisibilityResponsePayload = {
+  requestId: number;
+  supported: boolean;
+  datasets: VisibilityDatasetResponse[];
+};
+
+type GpuAdapter = {
+  requestDevice: () => Promise<GpuDevice>;
+};
+
+type GpuDevice = {
+  queue: {
+    writeBuffer: (
+      buffer: GpuBuffer,
+      offset: number,
+      data: ArrayBuffer | ArrayBufferView,
+    ) => void;
+    submit: (commands: unknown[]) => void;
+  };
+  createBuffer: (options: {
+    size: number;
+    usage: number;
+  }) => GpuBuffer;
+  createBindGroup: (options: {
+    layout: unknown;
+    entries: Array<{
+      binding: number;
+      resource: { buffer: GpuBuffer };
+    }>;
+  }) => unknown;
+  createCommandEncoder: () => GpuCommandEncoder;
+  createComputePipeline: (options: {
+    layout: "auto";
+    compute: {
+      module: GpuShaderModule;
+      entryPoint: string;
+    };
+  }) => GpuComputePipeline;
+  createShaderModule: (options: { code: string }) => GpuShaderModule;
+  lost: Promise<unknown>;
+};
+
+type GpuBuffer = {
+  destroy: () => void;
+  mapAsync: (mode: number) => Promise<void>;
+  getMappedRange: () => ArrayBuffer;
+  unmap: () => void;
+};
+
+type GpuCommandEncoder = {
+  beginComputePass: () => GpuComputePassEncoder;
+  copyBufferToBuffer: (
+    source: GpuBuffer,
+    sourceOffset: number,
+    destination: GpuBuffer,
+    destinationOffset: number,
+    size: number,
+  ) => void;
+  finish: () => unknown;
+};
+
+type GpuComputePassEncoder = {
+  setPipeline: (pipeline: GpuComputePipeline) => void;
+  setBindGroup: (index: number, bindGroup: unknown) => void;
+  dispatchWorkgroups: (x: number) => void;
+  end: () => void;
+};
+
+type GpuComputePipeline = {
+  getBindGroupLayout: (index: number) => unknown;
+};
+
+type GpuShaderModule = unknown;
+
+type NavigatorWithGpu = Navigator & {
+  gpu: {
+    requestAdapter: (options?: { powerPreference?: "high-performance" | "low-power" }) => Promise<GpuAdapter | null>;
+  };
+};
+
+const WORKGROUP_SIZE = 64;
+const BOUNDS_BUFFER_SIZE = 16;
+
+const GPU_BUFFER_USAGE = {
+  MAP_READ: 0x0001,
+  COPY_SRC: 0x0004,
+  COPY_DST: 0x0008,
+  UNIFORM: 0x0040,
+  STORAGE: 0x0080,
+} as const;
+
+const GPU_MAP_MODE = {
+  READ: 0x0001,
+} as const;
+
+const shaderCode = /* wgsl */ `
+struct Bounds {
+  west: f32,
+  east: f32,
+  south: f32,
+  north: f32,
+}
+
+@group(0) @binding(0) var<storage, read> coordinates: array<vec2<f32>>;
+@group(0) @binding(1) var<storage, read_write> visibility: array<u32>;
+@group(0) @binding(2) var<uniform> bounds: Bounds;
+
+@compute @workgroup_size(64)
+fn main(@builtin(global_invocation_id) globalId: vec3<u32>) {
+  let index = globalId.x;
+  if (index >= arrayLength(&coordinates)) {
+    return;
+  }
+
+  let coord = coordinates[index];
+  let withinLongitude =
+    (bounds.west <= bounds.east && coord.x >= bounds.west && coord.x <= bounds.east) ||
+    (bounds.west > bounds.east && (coord.x >= bounds.west || coord.x <= bounds.east));
+  let withinLatitude = coord.y >= bounds.south && coord.y <= bounds.north;
+
+  visibility[index] = select(0u, 1u, withinLongitude && withinLatitude);
+}
+`;
+
+let devicePromise: Promise<GpuDevice | null> | null = null;
+let pipelinePromise: Promise<GpuComputePipeline | null> | null = null;
+
+const getGpuDevice = async (): Promise<GpuDevice | null> => {
+  if (typeof navigator === "undefined" || !("gpu" in navigator)) return null;
+
+  const gpuNavigator = navigator as NavigatorWithGpu;
+  const adapter = await gpuNavigator.gpu.requestAdapter({
+    powerPreference: "high-performance",
+  });
+  if (!adapter) return null;
+
+  return (await adapter.requestDevice()) as unknown as GpuDevice;
+};
+
+const getDevice = async (): Promise<GpuDevice | null> => {
+  if (!devicePromise) {
+    devicePromise = getGpuDevice();
+  }
+
+  const device = await devicePromise;
+  if (!device) {
+    devicePromise = null;
+  }
+
+  return device;
+};
+
+const getPipeline = async (): Promise<GpuComputePipeline | null> => {
+  if (!pipelinePromise) {
+    pipelinePromise = (async () => {
+      const device = await getDevice();
+      if (!device) return null;
+
+      const pipeline = device.createComputePipeline({
+        layout: "auto",
+        compute: {
+          module: device.createShaderModule({ code: shaderCode }),
+          entryPoint: "main",
+        },
+      });
+
+      device.lost.then(() => {
+        devicePromise = null;
+        pipelinePromise = null;
+      });
+
+      return pipeline;
+    })();
+  }
+
+  const pipeline = await pipelinePromise;
+  if (!pipeline) {
+    pipelinePromise = null;
+  }
+
+  return pipeline;
+};
+
+const processDataset = async (
+  device: GpuDevice,
+  pipeline: GpuComputePipeline,
+  bounds: ViewportBounds,
+  coordinatesBuffer: ArrayBuffer,
+): Promise<ArrayBuffer> => {
+  const pointCount = coordinatesBuffer.byteLength / (Float32Array.BYTES_PER_ELEMENT * 2);
+  if (pointCount === 0) return new Uint32Array(0).buffer;
+
+  const storageBuffer = device.createBuffer({
+    size: coordinatesBuffer.byteLength,
+    usage: GPU_BUFFER_USAGE.STORAGE | GPU_BUFFER_USAGE.COPY_DST,
+  });
+  device.queue.writeBuffer(storageBuffer, 0, coordinatesBuffer);
+
+  const visibilityBuffer = device.createBuffer({
+    size: pointCount * Uint32Array.BYTES_PER_ELEMENT,
+    usage: GPU_BUFFER_USAGE.STORAGE | GPU_BUFFER_USAGE.COPY_SRC,
+  });
+
+  const readbackBuffer = device.createBuffer({
+    size: pointCount * Uint32Array.BYTES_PER_ELEMENT,
+    usage: GPU_BUFFER_USAGE.COPY_DST | GPU_BUFFER_USAGE.MAP_READ,
+  });
+
+  const boundsBuffer = device.createBuffer({
+    size: BOUNDS_BUFFER_SIZE,
+    usage: GPU_BUFFER_USAGE.UNIFORM | GPU_BUFFER_USAGE.COPY_DST,
+  });
+  device.queue.writeBuffer(
+    boundsBuffer,
+    0,
+    new Float32Array([bounds.west, bounds.east, bounds.south, bounds.north]),
+  );
+
+  const commandEncoder = device.createCommandEncoder();
+  const pass = commandEncoder.beginComputePass();
+  pass.setPipeline(pipeline);
+  pass.setBindGroup(
+    0,
+    device.createBindGroup({
+      layout: pipeline.getBindGroupLayout(0),
+      entries: [
+        { binding: 0, resource: { buffer: storageBuffer } },
+        { binding: 1, resource: { buffer: visibilityBuffer } },
+        { binding: 2, resource: { buffer: boundsBuffer } },
+      ],
+    }),
+  );
+  pass.dispatchWorkgroups(Math.ceil(pointCount / WORKGROUP_SIZE));
+  pass.end();
+
+  commandEncoder.copyBufferToBuffer(
+    visibilityBuffer,
+    0,
+    readbackBuffer,
+    0,
+    pointCount * Uint32Array.BYTES_PER_ELEMENT,
+  );
+
+  device.queue.submit([commandEncoder.finish()]);
+  await readbackBuffer.mapAsync(GPU_MAP_MODE.READ);
+
+  const mapped = readbackBuffer.getMappedRange().slice(0);
+  readbackBuffer.unmap();
+
+  storageBuffer.destroy();
+  visibilityBuffer.destroy();
+  readbackBuffer.destroy();
+  boundsBuffer.destroy();
+
+  return mapped;
+};
+
+const workerGlobal = self as DedicatedWorkerGlobalScope;
+
+workerGlobal.onmessage = async (event: MessageEvent<VisibilityRequestPayload>) => {
+  const { requestId, bounds, datasets } = event.data;
+  const pipeline = await getPipeline();
+
+  if (!pipeline) {
+    const response: VisibilityResponsePayload = {
+      requestId,
+      supported: false,
+      datasets: [],
+    };
+    workerGlobal.postMessage(response);
+    return;
+  }
+
+  const device = await getDevice();
+  if (!device) {
+    const response: VisibilityResponsePayload = {
+      requestId,
+      supported: false,
+      datasets: [],
+    };
+    workerGlobal.postMessage(response);
+    return;
+  }
+
+  try {
+    const processed = await Promise.all(
+      datasets.map(async (dataset) => ({
+        key: dataset.key,
+        visibility: await processDataset(device, pipeline, bounds, dataset.coordinates),
+      })),
+    );
+
+    const response: VisibilityResponsePayload = {
+      requestId,
+      supported: true,
+      datasets: processed,
+    };
+
+    workerGlobal.postMessage(
+      response,
+      processed.map((dataset) => dataset.visibility),
+    );
+  } catch {
+    pipelinePromise = null;
+    devicePromise = null;
+
+    const response: VisibilityResponsePayload = {
+      requestId,
+      supported: false,
+      datasets: [],
+    };
+    workerGlobal.postMessage(response);
+  }
+};


### PR DESCRIPTION
Adds an optional WebGPU-backed viewport culling path for the global signal markers while preserving the existing CPU fallback.

### What changed
- Added `useWebGpuVisibility` and a dedicated WebGPU worker to batch viewport culling off the main thread.
- Wired the global EONET, tsunami, and air-quality marker lists to use the WebGPU masks when supported.
- Kept the existing CPU bounds check as a fallback for browsers without WebGPU or for small datasets.
- Added a small WebGPU capability helper and exported the hook for future reuse.

### Verification
- `bun run build`

### Notes
- This does not replace MapLibre rendering itself; it accelerates the app’s marker preprocessing where WebGPU is actually useful in the current architecture.