### PR TITLE
feat(ui): sidebar & mobile drawer redesign with brand-guidelines palette

### DIFF
--- a/src/components/global-activity.tsx
+++ b/src/components/global-activity.tsx
@@ -103,8 +103,7 @@ const getEonetCategoryVisual = (category: string) => {
   if (normalized.includes("fire")) {
     return {
       icon: Flame,
-      className:
-        "bg-orange-500/20 text-orange-700 dark:bg-orange-500/30 dark:text-orange-200",
+      className: "bg-tone-earthquake-bg text-tone-earthquake-fg",
       label: "Wildfire",
     };
   }
@@ -112,8 +111,7 @@ const getEonetCategoryVisual = (category: string) => {
   if (normalized.includes("storm")) {
     return {
       icon: CloudRain,
-      className:
-        "bg-blue-500/20 text-blue-700 dark:bg-blue-500/30 dark:text-blue-200",
+      className: "bg-tone-info-bg text-tone-info-fg",
       label: "Storms",
     };
   }
@@ -121,8 +119,7 @@ const getEonetCategoryVisual = (category: string) => {
   if (normalized.includes("flood")) {
     return {
       icon: Waves,
-      className:
-        "bg-cyan-500/20 text-cyan-700 dark:bg-cyan-500/30 dark:text-cyan-200",
+      className: "bg-tone-tsunami-bg text-tone-tsunami-fg",
       label: "Floods",
     };
   }
@@ -130,8 +127,7 @@ const getEonetCategoryVisual = (category: string) => {
   if (normalized.includes("drought")) {
     return {
       icon: Sun,
-      className:
-        "bg-amber-500/20 text-amber-700 dark:bg-amber-500/30 dark:text-amber-200",
+      className: "bg-tone-eonet-bg text-tone-eonet-fg",
       label: "Drought",
     };
   }
@@ -139,8 +135,7 @@ const getEonetCategoryVisual = (category: string) => {
   if (normalized.includes("ice")) {
     return {
       icon: Snowflake,
-      className:
-        "bg-slate-500/20 text-slate-700 dark:bg-slate-500/30 dark:text-slate-200",
+      className: "bg-tone-meta-bg text-tone-meta-fg",
       label: "Iceberg",
     };
   }
@@ -148,8 +143,7 @@ const getEonetCategoryVisual = (category: string) => {
   if (normalized.includes("volcano")) {
     return {
       icon: Mountain,
-      className:
-        "bg-red-500/20 text-red-700 dark:bg-red-500/30 dark:text-red-200",
+      className: "bg-tone-danger-bg text-tone-danger-fg",
       label: "Volcanoes",
     };
   }
@@ -157,16 +151,14 @@ const getEonetCategoryVisual = (category: string) => {
   if (normalized.includes("dust")) {
     return {
       icon: Wind,
-      className:
-        "bg-yellow-500/20 text-yellow-700 dark:bg-yellow-500/30 dark:text-yellow-200",
+      className: "bg-tone-warning-bg text-tone-warning-fg",
       label: "Dust",
     };
   }
 
   return {
     icon: Globe2,
-    className:
-      "bg-amber-500/20 text-amber-700 dark:bg-amber-500/30 dark:text-amber-200",
+    className: "bg-tone-eonet-bg text-tone-eonet-fg",
     label: category,
   };
 };
@@ -184,15 +176,15 @@ const getTsunamiSeverityRank = (severity: string): number => {
 const getTsunamiSeverityBadgeClass = (severity: string): string => {
   const normalized = severity.toLowerCase();
   if (normalized.includes("extreme") || normalized.includes("severe")) {
-    return "bg-red-500/20 text-red-700 dark:bg-red-500/30 dark:text-red-200";
+    return "bg-tone-danger-bg text-tone-danger-fg";
   }
   if (normalized.includes("major")) {
-    return "bg-orange-500/20 text-orange-700 dark:bg-orange-500/30 dark:text-orange-200";
+    return "bg-tone-earthquake-bg text-tone-earthquake-fg";
   }
   if (normalized.includes("moderate")) {
-    return "bg-amber-500/20 text-amber-700 dark:bg-amber-500/30 dark:text-amber-200";
+    return "bg-tone-warning-bg text-tone-warning-fg";
   }
-  return "bg-sky-500/20 text-sky-700 dark:bg-sky-500/30 dark:text-sky-200";
+  return "bg-tone-tsunami-bg text-tone-tsunami-fg";
 };
 
 const formatTime = (date: Date): string => {
@@ -292,13 +284,13 @@ const GlobalActivity = ({
           label: formatRelativeTime(event.date),
           icon: Clock3,
           className:
-            "bg-indigo-500/20 text-indigo-700 dark:bg-indigo-500/30 dark:text-indigo-200",
+            "bg-tone-info-bg text-tone-info-fg",
         },
         {
           label: `${formatCoordinate(event.coordinates[1], "N", "S")} ${formatCoordinate(event.coordinates[0], "E", "W")}`,
           icon: MapPin,
           className:
-            "bg-slate-500/15 text-slate-700 dark:bg-slate-500/25 dark:text-slate-200",
+            "bg-tone-meta-bg text-tone-meta-fg",
         },
       ]),
     };
@@ -325,26 +317,26 @@ const GlobalActivity = ({
           label: `${site.parameter.toUpperCase()} ${value} ${site.unit}`,
           icon: Gauge,
           className:
-            "bg-emerald-500/20 text-emerald-700 dark:bg-emerald-500/30 dark:text-emerald-200",
+            "bg-tone-airquality-bg text-tone-airquality-fg",
         },
         {
           label: site.measuredAt ? formatRelativeTime(site.measuredAt) : "Time unknown",
           icon: Clock3,
           className:
-            "bg-cyan-500/20 text-cyan-700 dark:bg-cyan-500/30 dark:text-cyan-200",
+            "bg-tone-tsunami-bg text-tone-tsunami-fg",
         },
         {
           label: coordinateLabel,
           icon: MapPin,
           className:
-            "bg-slate-500/15 text-slate-700 dark:bg-slate-500/25 dark:text-slate-200",
+            "bg-tone-meta-bg text-tone-meta-fg",
         },
         site.coveragePercent !== null && site.coveragePercent !== undefined
           ? {
               label: `Coverage ${site.coveragePercent.toFixed(0)}%`,
               icon: Activity,
               className:
-                "bg-lime-500/20 text-lime-700 dark:bg-lime-500/30 dark:text-lime-200",
+                "bg-tone-airquality-bg text-tone-airquality-fg",
             }
           : null,
       ]),
@@ -367,13 +359,13 @@ const GlobalActivity = ({
         label: alert.sent ? formatRelativeTime(alert.sent) : "Time unknown",
         icon: Clock3,
         className:
-          "bg-indigo-500/20 text-indigo-700 dark:bg-indigo-500/30 dark:text-indigo-200",
+          "bg-tone-info-bg text-tone-info-fg",
       },
       {
         label: "NWS source",
         icon: Waves,
         className:
-          "bg-sky-500/20 text-sky-700 dark:bg-sky-500/30 dark:text-sky-200",
+          "bg-tone-tsunami-bg text-tone-tsunami-fg",
       },
     ]),
   }));
@@ -412,7 +404,7 @@ const GlobalActivity = ({
             <MiniSignal
               label="NASA EONET Live Signals"
               icon={Globe2}
-              toneClassName="bg-amber-500/20 text-amber-700 dark:bg-amber-500/30 dark:text-amber-200"
+              toneClassName="bg-tone-eonet-bg text-tone-eonet-fg"
               onClick={() => onOpenSection?.("global-live-events")}
               isLoading={eonetState.isLoading}
               detail={
@@ -428,7 +420,7 @@ const GlobalActivity = ({
             <MiniSignal
               label="OpenAQ"
               icon={Wind}
-              toneClassName="bg-emerald-500/20 text-emerald-700 dark:bg-emerald-500/30 dark:text-emerald-200"
+              toneClassName="bg-tone-airquality-bg text-tone-airquality-fg"
               onClick={() => onOpenSection?.("global-openaq")}
               isLoading={airQualityState.isLoading}
               detail={
@@ -445,7 +437,7 @@ const GlobalActivity = ({
             <MiniSignal
               label="NWS Tsunami Alerts"
               icon={Waves}
-              toneClassName="bg-sky-500/20 text-sky-700 dark:bg-sky-500/30 dark:text-sky-200"
+              toneClassName="bg-tone-tsunami-bg text-tone-tsunami-fg"
               onClick={() => onOpenSection?.("global-tsunami")}
               isLoading={tsunamiState.isLoading}
               detail={
@@ -486,8 +478,8 @@ const GlobalActivity = ({
                 lastUpdated={eonetState.lastUpdated}
                 onRefresh={eonetState.refetch}
                 items={eventItems}
-                toneClassName="bg-amber-500/20 text-amber-700 dark:bg-amber-500/30 dark:text-amber-200"
-                itemToneClassName="bg-amber-500/20 text-amber-700 dark:bg-amber-500/30 dark:text-amber-200"
+                toneClassName="bg-tone-eonet-bg text-tone-eonet-fg"
+                itemToneClassName="bg-tone-eonet-bg text-tone-eonet-fg"
               />
             </div>
           ) : null}
@@ -509,8 +501,8 @@ const GlobalActivity = ({
                 lastUpdated={airQualityState.lastUpdated}
                 onRefresh={airQualityState.refetch}
                 items={airItems}
-                toneClassName="bg-emerald-500/20 text-emerald-700 dark:bg-emerald-500/30 dark:text-emerald-200"
-                itemToneClassName="bg-emerald-500/20 text-emerald-700 dark:bg-emerald-500/30 dark:text-emerald-200"
+                toneClassName="bg-tone-airquality-bg text-tone-airquality-fg"
+                itemToneClassName="bg-tone-airquality-bg text-tone-airquality-fg"
               />
             </div>
           ) : null}
@@ -532,8 +524,8 @@ const GlobalActivity = ({
                 lastUpdated={tsunamiState.lastUpdated}
                 onRefresh={tsunamiState.refetch}
                 items={tsunamiItems}
-                toneClassName="bg-sky-500/20 text-sky-700 dark:bg-sky-500/30 dark:text-sky-200"
-                itemToneClassName="bg-sky-500/20 text-sky-700 dark:bg-sky-500/30 dark:text-sky-200"
+                toneClassName="bg-tone-tsunami-bg text-tone-tsunami-fg"
+                itemToneClassName="bg-tone-tsunami-bg text-tone-tsunami-fg"
               />
             </div>
           ) : null}

--- a/src/components/hazr-earthquake-item.tsx
+++ b/src/components/hazr-earthquake-item.tsx
@@ -79,30 +79,30 @@ const EarthquakeItem = ({
     {
       label: `Magnitude ${earthquake.magnitude.toFixed(1)}`,
       icon: Gauge,
-      className: "bg-indigo-500/20 text-indigo-700 dark:bg-indigo-500/30 dark:text-indigo-200",
+      className: "bg-tone-info-bg text-tone-info-fg",
     },
     {
       label: `Depth ${earthquake.depth.toFixed(1)}km`,
       icon: Ruler,
-      className: "bg-slate-500/15 text-slate-700 dark:bg-slate-500/25 dark:text-slate-200",
+      className: "bg-tone-meta-bg text-tone-meta-fg",
     },
     {
       label: `${formatRelativeTime(earthquake.time)}`,
       icon: Clock,
-      className: "bg-amber-500/20 text-amber-700 dark:bg-amber-500/30 dark:text-amber-200",
+      className: "bg-tone-warning-bg text-tone-warning-fg",
     },
     earthquake.mmi !== null
       ? {
           label: `MMI ${earthquake.mmi.toFixed(1)}`,
           icon: Gauge,
-          className: "bg-violet-500/20 text-violet-700 dark:bg-violet-500/30 dark:text-violet-200",
+          className: "bg-tone-info-bg text-tone-info-fg",
         }
       : null,
     earthquake.tsunami
       ? {
           label: "Tsunami",
           icon: Waves,
-          className: "bg-sky-500/20 text-sky-700 dark:bg-sky-500/30 dark:text-sky-200",
+          className: "bg-tone-tsunami-bg text-tone-tsunami-fg",
         }
       : null,
     earthquake.alert
@@ -110,10 +110,10 @@ const EarthquakeItem = ({
           label: `Alert ${earthquake.alert}`,
           icon: AlertTriangle,
           className: cn(
-            "bg-red-500/20 text-red-700 dark:bg-red-500/30 dark:text-red-200",
-            earthquake.alert === "yellow" && "bg-yellow-500/20 text-yellow-700 dark:bg-yellow-500/30 dark:text-yellow-200",
-            earthquake.alert === "orange" && "bg-orange-500/20 text-orange-700 dark:bg-orange-500/30 dark:text-orange-200",
-            earthquake.alert === "green" && "bg-emerald-500/20 text-emerald-700 dark:bg-emerald-500/30 dark:text-emerald-200",
+            "bg-tone-danger-bg text-tone-danger-fg",
+            earthquake.alert === "yellow" && "bg-tone-warning-bg text-tone-warning-fg",
+            earthquake.alert === "orange" && "bg-tone-earthquake-bg text-tone-earthquake-fg",
+            earthquake.alert === "green" && "bg-tone-airquality-bg text-tone-airquality-fg",
           ),
         }
       : null,

--- a/src/components/hazr-settings-panel.tsx
+++ b/src/components/hazr-settings-panel.tsx
@@ -2,10 +2,7 @@
 
 import * as React from "react";
 import {
-  Activity,
-  Layers3,
   SlidersHorizontal,
-  Sparkles,
   RotateCw,
   X,
 } from "lucide-react";
@@ -28,9 +25,8 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { Slider } from "@/components/ui/slider";
 import { Switch } from "@/components/ui/switch";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Slider } from "@/components/ui/slider";
 import { cn } from "@/lib/utils";
 import type { EarthquakeMagnitude } from "@/types/api";
 import type {
@@ -116,25 +112,14 @@ function HazrSettingsPanel({
   };
 
   return (
-    <div className={cn("space-y-4", className)}>
-      <Tabs defaultValue="display" className="w-full">
-        <TabsList className="grid w-full grid-cols-3">
-          <TabsTrigger value="display">
-            <Sparkles className="size-4" />
-            Display
-          </TabsTrigger>
-          <TabsTrigger value="data">
-            <Activity className="size-4" />
-            Data
-          </TabsTrigger>
-          <TabsTrigger value="layers">
-            <Layers3 className="size-4" />
-            Layers
-          </TabsTrigger>
-        </TabsList>
-
-        <TabsContent value="display" className="space-y-3 pt-2">
-          <div className="grid gap-3 rounded-md border border-border/60 bg-muted/20 p-3">
+    <div className={cn("space-y-5", className)}>
+      {/* Display section */}
+      <div>
+        <p className="px-1 text-xs font-semibold uppercase tracking-wider text-muted-foreground/70">
+          Display
+        </p>
+        <div className="mt-1.5 rounded-lg border border-border/60 bg-muted/15 p-3">
+          <div className="space-y-3">
             <div className="flex items-center justify-between gap-3">
               <Label htmlFor={`${settingsId}-temperature-unit`}>Temperature Unit</Label>
               <Select
@@ -190,10 +175,16 @@ function HazrSettingsPanel({
               />
             </div>
           </div>
-        </TabsContent>
+        </div>
+      </div>
 
-        <TabsContent value="data" className="space-y-3 pt-2">
-          <div className="grid gap-3 rounded-md border border-border/60 bg-muted/20 p-3">
+      {/* Data section */}
+      <div>
+        <p className="px-1 text-xs font-semibold uppercase tracking-wider text-muted-foreground/70">
+          Data
+        </p>
+        <div className="mt-1.5 rounded-lg border border-border/60 bg-muted/15 p-3">
+          <div className="space-y-3">
             <div className="flex items-center justify-between gap-3">
               <Label htmlFor={`${settingsId}-usgs-magnitude`}>USGS Feed Magnitude</Label>
               <Select
@@ -255,9 +246,15 @@ function HazrSettingsPanel({
               />
             </div>
           </div>
-        </TabsContent>
+        </div>
+      </div>
 
-        <TabsContent value="layers" className="space-y-2 pt-2">
+      {/* Sources section */}
+      <div>
+        <p className="px-1 text-xs font-semibold uppercase tracking-wider text-muted-foreground/70">
+          Sources
+        </p>
+        <div className="mt-1.5 space-y-2">
           <SourceToggleRow
             id={`${settingsId}-earthquakes`}
             label="USGS Earthquakes"
@@ -286,10 +283,11 @@ function HazrSettingsPanel({
             checked={layerVisibility.tsunami}
             onCheckedChange={(checked) => updateLayerVisibility("tsunami", checked)}
           />
-        </TabsContent>
-      </Tabs>
+        </div>
+      </div>
+
       {showInlineReset && onResetDefaults ? (
-        <div className="pt-2">
+        <div className="pt-1">
           <Button variant="outline" className="w-full" onClick={onResetDefaults}>
             Reset Defaults
           </Button>

--- a/src/components/hazr-settings-panel.tsx
+++ b/src/components/hazr-settings-panel.tsx
@@ -25,8 +25,8 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Switch } from "@/components/ui/switch";
-import { Slider } from "@/components/ui/slider";
 import { cn } from "@/lib/utils";
 import type { EarthquakeMagnitude } from "@/types/api";
 import type {
@@ -54,10 +54,6 @@ type HazrSettingsDialogProps = HazrSettingsPanelProps & {
   onResetDefaults: () => void;
 };
 
-const clampToStep = (value: number, min: number, max: number, step: number) => {
-  const clamped = Math.max(min, Math.min(max, value));
-  return Math.round(clamped / step) * step;
-};
 
 const SourceToggleRow = ({
   id,
@@ -120,41 +116,35 @@ function HazrSettingsPanel({
         </p>
         <div className="mt-1.5 rounded-lg border border-border/60 bg-muted/15 p-3">
           <div className="space-y-3">
-            <div className="flex items-center justify-between gap-3">
-              <Label htmlFor={`${settingsId}-temperature-unit`}>Temperature Unit</Label>
-              <Select
+            <div className="space-y-1.5">
+              <Label>Temperature Unit</Label>
+              <Tabs
                 value={settings.temperatureUnit}
-                onValueChange={(value: TemperatureUnit) =>
+                onValueChange={(value) =>
                   updateSettings({ temperatureUnit: value as TemperatureUnit })
                 }
               >
-                <SelectTrigger id={`${settingsId}-temperature-unit`} className="w-36">
-                  <SelectValue placeholder="Temperature unit" />
-                </SelectTrigger>
-                <SelectContent align="end">
-                  <SelectItem value="celsius">Celsius (°C)</SelectItem>
-                  <SelectItem value="fahrenheit">Fahrenheit (°F)</SelectItem>
-                  <SelectItem value="kelvin">Kelvin (K)</SelectItem>
-                </SelectContent>
-              </Select>
+                <TabsList className="w-full">
+                  <TabsTrigger value="celsius" className="flex-1">°C</TabsTrigger>
+                  <TabsTrigger value="fahrenheit" className="flex-1">°F</TabsTrigger>
+                  <TabsTrigger value="kelvin" className="flex-1">K</TabsTrigger>
+                </TabsList>
+              </Tabs>
             </div>
 
-            <div className="flex items-center justify-between gap-3">
-              <Label htmlFor={`${settingsId}-time-format`}>Time Format</Label>
-              <Select
+            <div className="space-y-1.5">
+              <Label>Time Format</Label>
+              <Tabs
                 value={settings.timeFormat}
-                onValueChange={(value: TimeFormat) =>
-                  updateSettings({ timeFormat: value })
+                onValueChange={(value) =>
+                  updateSettings({ timeFormat: value as TimeFormat })
                 }
               >
-                <SelectTrigger id={`${settingsId}-time-format`} className="w-36">
-                  <SelectValue placeholder="Time format" />
-                </SelectTrigger>
-                <SelectContent align="end">
-                  <SelectItem value="12h">12-hour</SelectItem>
-                  <SelectItem value="24h">24-hour</SelectItem>
-                </SelectContent>
-              </Select>
+                <TabsList className="w-full">
+                  <TabsTrigger value="12h" className="flex-1">12-hour</TabsTrigger>
+                  <TabsTrigger value="24h" className="flex-1">24-hour</TabsTrigger>
+                </TabsList>
+              </Tabs>
             </div>
 
             <div className="flex items-start justify-between gap-3 rounded-md border border-border/60 bg-background/70 px-3 py-2.5">
@@ -206,44 +196,48 @@ function HazrSettingsPanel({
               </Select>
             </div>
 
-            <div className="space-y-2">
-              <div className="flex items-center justify-between gap-3">
-                <Label htmlFor={`${settingsId}-openaq-limit`}>OpenAQ Site Limit</Label>
-                <span className="text-xs text-muted-foreground">
-                  {settings.openAqLimit}
-                </span>
-              </div>
-              <Slider
-                id={`${settingsId}-openaq-limit`}
-                min={50}
-                max={300}
-                step={50}
-                value={[settings.openAqLimit]}
+            <div className="flex items-center justify-between gap-3">
+              <Label htmlFor={`${settingsId}-openaq-limit`}>OpenAQ Site Limit</Label>
+              <Select
+                value={String(settings.openAqLimit)}
                 onValueChange={(value) =>
-                  updateSettings({
-                    openAqLimit: clampToStep(value[0] ?? 200, 50, 300, 50),
-                  })
+                  updateSettings({ openAqLimit: Number(value) })
                 }
-              />
+              >
+                <SelectTrigger id={`${settingsId}-openaq-limit`} className="w-24">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent align="end">
+                  <SelectItem value="50">50</SelectItem>
+                  <SelectItem value="100">100</SelectItem>
+                  <SelectItem value="150">150</SelectItem>
+                  <SelectItem value="200">200</SelectItem>
+                  <SelectItem value="250">250</SelectItem>
+                  <SelectItem value="300">300</SelectItem>
+                </SelectContent>
+              </Select>
             </div>
 
-            <div className="space-y-2">
-              <div className="flex items-center justify-between gap-3">
-                <Label htmlFor={`${settingsId}-eonet-limit`}>NASA EONET Event Limit</Label>
-                <span className="text-xs text-muted-foreground">{settings.eonetLimit}</span>
-              </div>
-              <Slider
-                id={`${settingsId}-eonet-limit`}
-                min={50}
-                max={300}
-                step={50}
-                value={[settings.eonetLimit]}
+            <div className="flex items-center justify-between gap-3">
+              <Label htmlFor={`${settingsId}-eonet-limit`}>NASA EONET Event Limit</Label>
+              <Select
+                value={String(settings.eonetLimit)}
                 onValueChange={(value) =>
-                  updateSettings({
-                    eonetLimit: clampToStep(value[0] ?? 200, 50, 300, 50),
-                  })
+                  updateSettings({ eonetLimit: Number(value) })
                 }
-              />
+              >
+                <SelectTrigger id={`${settingsId}-eonet-limit`} className="w-24">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent align="end">
+                  <SelectItem value="50">50</SelectItem>
+                  <SelectItem value="100">100</SelectItem>
+                  <SelectItem value="150">150</SelectItem>
+                  <SelectItem value="200">200</SelectItem>
+                  <SelectItem value="250">250</SelectItem>
+                  <SelectItem value="300">300</SelectItem>
+                </SelectContent>
+              </Select>
             </div>
           </div>
         </div>

--- a/src/components/map/controls/map-layers-control.tsx
+++ b/src/components/map/controls/map-layers-control.tsx
@@ -141,7 +141,7 @@ export function MapLayersControl({
       >
         <div className="absolute inset-0 bg-gradient-to-b from-white/10 to-transparent dark:from-white/5 dark:to-transparent pointer-events-none" />
         
-        <div className="flex items-center justify-between px-3.5 py-2.5 border-b border-border/40 bg-muted/20 relative z-10">
+        <div className="flex items-center justify-between px-3 py-2 border-b border-border/40 bg-muted/20 relative z-10">
           <h2 className="text-[13px] font-semibold text-foreground tracking-wide">Map details</h2>
           <button 
             onClick={() => setIsOpen(false)} 
@@ -152,9 +152,9 @@ export function MapLayersControl({
           </button>
         </div>
 
-        <div className="p-2.5 space-y-3 relative z-10">
+        <div className="p-2 space-y-2 relative z-10">
           <div>
-            <h3 className="text-[11px] font-bold uppercase tracking-wider text-muted-foreground mb-2">Map Type</h3>
+            <h3 className="text-[11px] font-bold uppercase tracking-wider text-muted-foreground mb-1">Map Type</h3>
             <div className="grid grid-cols-2 gap-1.5">
                <MapTypeButton 
                   label="Auto" 
@@ -183,10 +183,9 @@ export function MapLayersControl({
             </div>
           </div>
 
-          <div className="h-px bg-border/40 w-full" />
 
           <div>
-            <h3 className="text-[11px] font-bold uppercase tracking-wider text-muted-foreground mb-2">Map Details</h3>
+            <h3 className="text-[11px] font-bold uppercase tracking-wider text-muted-foreground mb-1">Map Details</h3>
             <div className="grid grid-cols-2 gap-1.5">
                <MapTypeButton 
                   label="3D Globe" 
@@ -224,7 +223,7 @@ function MapTypeButton({ label, selected, onClick, icon }: { label: string; sele
         )}
       </div>
       <span className={cn(
-        "text-[9px] tracking-wide transition-colors",
+        "text-sm tracking-wide transition-colors",
         selected ? "text-primary font-semibold" : "text-muted-foreground font-medium group-hover:text-foreground"
       )}>
         {label}

--- a/src/components/map/controls/map-layers-control.tsx
+++ b/src/components/map/controls/map-layers-control.tsx
@@ -137,11 +137,11 @@ export function MapLayersControl({
         side="top"
         align="start"
         sideOffset={16}
-        className="w-[320px] p-0 rounded-[20px] border border-border/40 bg-background/85 backdrop-blur-3xl shadow-xs z-50 pointer-events-auto supports-backdrop-filter:bg-background/60 overflow-hidden relative"
+        className="w-[280px] p-0 rounded-[20px] border border-border/40 bg-background/85 backdrop-blur-3xl shadow-xs z-50 pointer-events-auto supports-backdrop-filter:bg-background/60 overflow-hidden relative"
       >
         <div className="absolute inset-0 bg-gradient-to-b from-white/10 to-transparent dark:from-white/5 dark:to-transparent pointer-events-none" />
         
-        <div className="flex items-center justify-between px-4 py-3 border-b border-border/40 bg-muted/20 relative z-10">
+        <div className="flex items-center justify-between px-3.5 py-2.5 border-b border-border/40 bg-muted/20 relative z-10">
           <h2 className="text-[13px] font-semibold text-foreground tracking-wide">Map details</h2>
           <button 
             onClick={() => setIsOpen(false)} 
@@ -152,10 +152,10 @@ export function MapLayersControl({
           </button>
         </div>
 
-        <div className="p-3 space-y-4 relative z-10">
+        <div className="p-2.5 space-y-3 relative z-10">
           <div>
-            <h3 className="text-[11px] font-bold uppercase tracking-wider text-muted-foreground mb-3">Map Type</h3>
-            <div className="grid grid-cols-2 gap-2">
+            <h3 className="text-[11px] font-bold uppercase tracking-wider text-muted-foreground mb-2">Map Type</h3>
+            <div className="grid grid-cols-2 gap-1.5">
                <MapTypeButton 
                   label="Auto" 
                   icon={<AutoMapSvg />} 
@@ -186,8 +186,8 @@ export function MapLayersControl({
           <div className="h-px bg-border/40 w-full" />
 
           <div>
-            <h3 className="text-[11px] font-bold uppercase tracking-wider text-muted-foreground mb-3">Map Details</h3>
-            <div className="grid grid-cols-2 gap-2">
+            <h3 className="text-[11px] font-bold uppercase tracking-wider text-muted-foreground mb-2">Map Details</h3>
+            <div className="grid grid-cols-2 gap-1.5">
                <MapTypeButton 
                   label="3D Globe" 
                   icon={<GlobeSvg />} 
@@ -212,19 +212,19 @@ function MapTypeButton({ label, selected, onClick, icon }: { label: string; sele
   return (
     <button 
       onClick={onClick}
-      className="flex flex-col items-center gap-1.5 group w-full focus:outline-none"
+      className="flex flex-col items-center gap-1 group w-full focus:outline-none"
     >
       <div className={cn(
-        "w-full max-w-[80px] aspect-square rounded-[10px] border-2 flex items-center justify-center overflow-hidden transition-all duration-300 relative bg-background mx-auto", 
+        "w-full max-w-[56px] aspect-square rounded-lg border-2 flex items-center justify-center overflow-hidden transition-all duration-300 relative bg-background mx-auto",
         selected ? "border-primary shadow-[0_0_0_2px_rgba(var(--primary),0.2)]" : "border-border/50 group-hover:border-foreground/30 group-hover:shadow-sm"
       )}>
         {icon}
         {selected && (
-          <div className="absolute top-1.5 right-1.5 size-2.5 bg-primary rounded-full border-2 border-background shadow-sm z-10" />
+          <div className="absolute top-1 right-1 size-2 bg-primary rounded-full border-2 border-background shadow-sm z-10" />
         )}
       </div>
       <span className={cn(
-        "text-[10px] tracking-wide transition-colors", 
+        "text-[9px] tracking-wide transition-colors",
         selected ? "text-primary font-semibold" : "text-muted-foreground font-medium group-hover:text-foreground"
       )}>
         {label}

--- a/src/components/map/controls/map-layers-control.tsx
+++ b/src/components/map/controls/map-layers-control.tsx
@@ -4,6 +4,7 @@ import { Layers, X } from "lucide-react";
 import { cn } from "@/lib/utils";
 import type { AppSettings } from "@/types/settings";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import { Separator } from "@/components/ui/separator";
 
 const LightMapSvg = () => (
   <svg viewBox="0 0 100 100" className="w-full h-full" fill="none" xmlns="http://www.w3.org/2000/svg">
@@ -183,9 +184,9 @@ export function MapLayersControl({
             </div>
           </div>
 
-
-          <div>
+          <div className="pt-1">
             <h3 className="text-[11px] font-bold uppercase tracking-wider text-muted-foreground mb-1">Map Details</h3>
+            <Separator className="mb-2" />
             <div className="grid grid-cols-2 gap-1.5">
                <MapTypeButton 
                   label="3D Globe" 

--- a/src/components/map/controls/map-layers-control.tsx
+++ b/src/components/map/controls/map-layers-control.tsx
@@ -138,7 +138,7 @@ export function MapLayersControl({
         side="top"
         align="start"
         sideOffset={16}
-        className="w-[280px] p-0 rounded-[20px] border border-border/40 bg-background/85 backdrop-blur-3xl shadow-xs z-50 pointer-events-auto supports-backdrop-filter:bg-background/60 overflow-hidden relative"
+        className="w-[240px] p-0 rounded-[20px] border border-border/40 bg-background/85 backdrop-blur-3xl shadow-xs z-50 pointer-events-auto supports-backdrop-filter:bg-background/60 overflow-hidden relative"
       >
         <div className="absolute inset-0 bg-gradient-to-b from-white/10 to-transparent dark:from-white/5 dark:to-transparent pointer-events-none" />
         

--- a/src/components/map/controls/map-overlay-ui.tsx
+++ b/src/components/map/controls/map-overlay-ui.tsx
@@ -312,7 +312,7 @@ export function MapOverlayUI({
                 />
                 <div
                   data-vaul-no-drag
-                  className="min-h-0 flex-1 overflow-y-auto overscroll-contain px-3 pb-3"
+                  className="min-h-0 flex-1 overflow-y-auto overscroll-contain px-3 pt-3 pb-3"
                 >
                   <div className="rounded-md border border-border/60 bg-muted/15 p-3">
                     <HazrSettingsPanel
@@ -346,7 +346,7 @@ export function MapOverlayUI({
                   description={`${earthquakes.length} in the last 24h`}
                   onClose={closeDrawer}
                 />
-                <div className="flex min-h-0 flex-1 flex-col px-3 pb-3">
+                <div className="flex min-h-0 flex-1 flex-col px-3 pt-3 pb-3">
                   {!layerVisibility.earthquakes ? (
                     <div className="flex min-h-0 flex-1 items-center justify-center rounded-md border border-border/60 bg-muted/15 px-3 py-6 text-center text-sm text-muted-foreground">
                       USGS earthquakes are hidden in settings.
@@ -454,7 +454,7 @@ export function MapOverlayUI({
                 />
                 <div
                   data-vaul-no-drag
-                  className="min-h-0 flex-1 overflow-y-auto overscroll-contain px-3 pb-3"
+                  className="min-h-0 flex-1 overflow-y-auto overscroll-contain px-3 pt-3 pb-3"
                 >
                   <div className="min-w-0 rounded-md border border-border/60 bg-muted/15 p-2">
                     {!layerVisibility.eonet &&
@@ -504,7 +504,7 @@ export function MapOverlayUI({
                 />
                 <div
                   data-vaul-no-drag
-                  className="min-h-0 flex-1 overflow-y-auto overscroll-contain px-3 pb-3"
+                  className="min-h-0 flex-1 overflow-y-auto overscroll-contain px-3 pt-3 pb-3"
                 >
                   <div className="min-w-0 space-y-3 rounded-md border border-border/60 bg-muted/15 p-2">
                   <WeatherDock

--- a/src/components/map/controls/map-overlay-ui.tsx
+++ b/src/components/map/controls/map-overlay-ui.tsx
@@ -126,11 +126,11 @@ function MobileDrawerHeader({
         <div className="flex min-w-0 items-center gap-2.5">
           <div
             className={cn(
-              "flex size-8 shrink-0 items-center justify-center rounded-md border border-white/20",
+              "flex size-8 shrink-0 items-center justify-center rounded-md",
               iconToneClassName,
             )}
           >
-            <Icon className="size-4 text-white" />
+            <Icon className="size-4" />
           </div>
           <div className="min-w-0">
             <h3 className="truncate text-sm font-semibold">{title}</h3>
@@ -305,7 +305,7 @@ export function MapOverlayUI({
               <>
                 <MobileDrawerHeader
                   icon={SlidersHorizontal}
-                  iconToneClassName="bg-slate-500"
+                  iconToneClassName="bg-tone-info-bg text-tone-info-fg"
                   title="Menu"
                   description="Settings and layer controls"
                   onClose={closeDrawer}
@@ -326,7 +326,7 @@ export function MapOverlayUI({
                   </div>
                   <div className="mt-3 rounded-md border border-border/60 bg-muted/15 p-3">
                     <div className="flex items-center gap-2 mb-3">
-                      <span className="inline-flex items-center justify-center rounded-md bg-blue-500/15 text-white">
+                      <span className="inline-flex items-center justify-center rounded-md bg-tone-info-bg text-tone-info-fg">
                         <Map className="size-5" />
                       </span>
                       <h3 className="text-sm font-semibold">About Hazr</h3>
@@ -341,7 +341,7 @@ export function MapOverlayUI({
               <>
                 <MobileDrawerHeader
                   icon={Activity}
-                  iconToneClassName="bg-red-500"
+                  iconToneClassName="bg-tone-earthquake-bg text-tone-earthquake-fg"
                   title="Live Earthquakes"
                   description={`${earthquakes.length} in the last 24h`}
                   onClose={closeDrawer}
@@ -447,7 +447,7 @@ export function MapOverlayUI({
               <>
                 <MobileDrawerHeader
                   icon={Globe2}
-                  iconToneClassName="bg-amber-500"
+                  iconToneClassName="bg-tone-eonet-bg text-tone-eonet-fg"
                   title="Global Signals"
                   description="NASA EONET, OpenAQ, and NWS Tsunami alerts"
                   onClose={closeDrawer}
@@ -497,7 +497,7 @@ export function MapOverlayUI({
               <>
                 <MobileDrawerHeader
                   icon={Cloud}
-                  iconToneClassName="bg-sky-500"
+                  iconToneClassName="bg-tone-tsunami-bg text-tone-tsunami-fg"
                   title="Weather"
                   description="Local conditions and hourly outlook"
                   onClose={closeDrawer}

--- a/src/components/map/controls/map-overlay-ui.tsx
+++ b/src/components/map/controls/map-overlay-ui.tsx
@@ -39,6 +39,7 @@ import { MobileBottomNav } from "@/components/mobile-bottom-nav";
 import { GlobalActivity } from "@/components/global-activity";
 import { HazrSettingsPanel } from "@/components/hazr-settings-panel";
 import { HazrAboutContent } from "@/components/hazr-about-dialog";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import type {
   ProcessedAirQualitySite,
   ProcessedEarthquake,
@@ -314,25 +315,35 @@ export function MapOverlayUI({
                   data-vaul-no-drag
                   className="min-h-0 flex-1 overflow-y-auto overscroll-contain px-3 pt-3 pb-3"
                 >
-                  <div className="rounded-md border border-border/60 bg-muted/15 p-3">
-                    <HazrSettingsPanel
-                      settings={appSettings}
-                      onSettingsChange={onAppSettingsChange}
-                      layerVisibility={layerVisibility}
-                      onLayerVisibilityChange={onLayerVisibilityChange}
-                      onResetDefaults={onResetDefaults}
-                      showInlineReset
-                    />
-                  </div>
-                  <div className="mt-3 rounded-md border border-border/60 bg-muted/15 p-3">
-                    <div className="flex items-center gap-2 mb-3">
-                      <span className="inline-flex items-center justify-center rounded-md bg-tone-info-bg text-tone-info-fg">
-                        <Map className="size-5" />
-                      </span>
-                      <h3 className="text-sm font-semibold">About Hazr</h3>
-                    </div>
-                    <HazrAboutContent />
-                  </div>
+                  <Tabs defaultValue="settings" className="w-full">
+                    <TabsList className="w-full">
+                      <TabsTrigger value="settings" className="flex-1">Settings</TabsTrigger>
+                      <TabsTrigger value="about" className="flex-1">About</TabsTrigger>
+                    </TabsList>
+                    <TabsContent value="settings" className="mt-3">
+                      <div className="rounded-md border border-border/60 bg-muted/15 p-3">
+                        <HazrSettingsPanel
+                          settings={appSettings}
+                          onSettingsChange={onAppSettingsChange}
+                          layerVisibility={layerVisibility}
+                          onLayerVisibilityChange={onLayerVisibilityChange}
+                          onResetDefaults={onResetDefaults}
+                          showInlineReset
+                        />
+                      </div>
+                    </TabsContent>
+                    <TabsContent value="about" className="mt-3">
+                      <div className="rounded-md border border-border/60 bg-muted/15 p-3">
+                        <div className="flex items-center gap-2 mb-3">
+                          <span className="inline-flex items-center justify-center rounded-md bg-tone-info-bg text-tone-info-fg">
+                            <Map className="size-5" />
+                          </span>
+                          <h3 className="text-sm font-semibold">About Hazr</h3>
+                        </div>
+                        <HazrAboutContent />
+                      </div>
+                    </TabsContent>
+                  </Tabs>
                 </div>
               </>
             ) : null}

--- a/src/components/map/controls/map-overlay-ui.tsx
+++ b/src/components/map/controls/map-overlay-ui.tsx
@@ -212,6 +212,7 @@ export function MapOverlayUI({
   const { is3D, toggle3D, isGlobe, toggleGlobe } = useMap3DMode(setIsMap3DMode, setIsMapGlobeMode);
   const isMobile = useIsMobile();
   const [quakePage, setQuakePage] = React.useState(1);
+  const [menuTab, setMenuTab] = React.useState("settings");
   const quakePageSize = 8;
   const totalQuakePages = Math.max(1, Math.ceil(earthquakes.length / quakePageSize));
   const paginatedEarthquakes = React.useMemo(() => {
@@ -231,6 +232,12 @@ export function MapOverlayUI({
     if (isMobile) return;
     setActiveMobileDrawer(null);
   }, [isMobile]);
+
+  React.useEffect(() => {
+    if (activeMobileDrawer === null) {
+      setMenuTab("settings");
+    }
+  }, [activeMobileDrawer]);
 
   const activateDrawer = React.useCallback((drawer: "menu" | "quakes" | "weather" | "global") => {
     setActiveMobileDrawer(drawer);
@@ -305,17 +312,17 @@ export function MapOverlayUI({
             {activeMobileDrawer === "menu" ? (
               <>
                 <MobileDrawerHeader
-                  icon={SlidersHorizontal}
+                  icon={menuTab === "settings" ? SlidersHorizontal : Map}
                   iconToneClassName="bg-tone-info-bg text-tone-info-fg"
-                  title="Menu"
-                  description="Settings and layer controls"
+                  title={menuTab === "settings" ? "Menu" : "About"}
+                  description={menuTab === "settings" ? "Settings and layer controls" : "About Hazr"}
                   onClose={closeDrawer}
                 />
                 <div
                   data-vaul-no-drag
                   className="min-h-0 flex-1 overflow-y-auto overscroll-contain px-3 pt-3 pb-3"
                 >
-                  <Tabs defaultValue="settings" className="w-full">
+                  <Tabs value={menuTab} onValueChange={setMenuTab} className="w-full">
                     <TabsList className="w-full">
                       <TabsTrigger value="settings" className="flex-1">Settings</TabsTrigger>
                       <TabsTrigger value="about" className="flex-1">About</TabsTrigger>

--- a/src/components/map/controls/map-overlay-ui.tsx
+++ b/src/components/map/controls/map-overlay-ui.tsx
@@ -121,7 +121,7 @@ function MobileDrawerHeader({
   onClose: () => void;
 }) {
   return (
-    <div className="border-b border-border/60 px-4 pb-3 pt-2">
+    <div className="border-b border-border/60 px-4 pb-4 pt-2">
       <div className="flex items-start justify-between gap-3">
         <div className="flex min-w-0 items-center gap-2.5">
           <div

--- a/src/components/seismic-activity.tsx
+++ b/src/components/seismic-activity.tsx
@@ -106,7 +106,7 @@ export const SeismicActivity = ({
             className="flex size-12 items-center justify-center rounded-md transition-colors hover:bg-muted/70"
             aria-label="USGS earthquakes"
           >
-            <div className="flex size-9 items-center justify-center rounded-md bg-orange-500/20 text-orange-700 dark:bg-orange-500/30 dark:text-orange-200">
+            <div className="flex size-9 items-center justify-center rounded-md bg-tone-earthquake-bg text-tone-earthquake-fg">
               {isLoading ? (
                 <Loader2 className="size-4 animate-spin" />
               ) : (
@@ -140,7 +140,7 @@ export const SeismicActivity = ({
         {/* Header */}
         <div className="my-2 flex items-center justify-between px-0">
           <div className="flex items-center gap-2">
-            <div className="rounded-md border border-orange-500/35 bg-orange-500/10 p-2.5 text-orange-600 dark:bg-orange-500/20 dark:text-orange-300">
+            <div className="rounded-md border border-tone-earthquake/35 bg-tone-earthquake-bg p-2.5 text-tone-earthquake-fg">
               <Mountain className="size-5" />
             </div>
             <div>

--- a/src/index.css
+++ b/src/index.css
@@ -6,72 +6,153 @@
 @custom-variant dark (&:is(.dark *));
 
 :root {
-    --background: oklch(1 0 0);
-    --foreground: oklch(0.145 0 0);
-    --card: oklch(1 0 0);
-    --card-foreground: oklch(0.145 0 0);
-    --popover: oklch(1 0 0);
-    --popover-foreground: oklch(0.145 0 0);
-    --primary: oklch(0.61 0.11 222);
-    --primary-foreground: oklch(0.98 0.02 201);
-    --secondary: oklch(0.967 0.001 286.375);
-    --secondary-foreground: oklch(0.21 0.006 285.885);
-    --muted: oklch(0.97 0 0);
-    --muted-foreground: oklch(0.556 0 0);
-    --accent: oklch(0.97 0 0);
-    --accent-foreground: oklch(0.205 0 0);
-    --destructive: oklch(0.58 0.22 27);
-    --border: oklch(0.922 0 0);
-    --input: oklch(0.922 0 0);
-    --ring: oklch(0.708 0 0);
-    --chart-1: oklch(0.87 0.12 207);
-    --chart-2: oklch(0.80 0.13 212);
-    --chart-3: oklch(0.71 0.13 215);
-    --chart-4: oklch(0.61 0.11 222);
-    --chart-5: oklch(0.52 0.09 223);
+    /* Surfaces — warm off-whites */
+    --background: oklch(0.98 0.003 80);          /* #faf9f5 */
+    --foreground: oklch(0.16 0.005 60);           /* #141413 warm near-black */
+    --card: oklch(0.97 0.004 80);
+    --card-foreground: oklch(0.16 0.005 60);
+    --popover: oklch(0.975 0.003 80);
+    --popover-foreground: oklch(0.16 0.005 60);
+
+    /* Primary — muted warm orange */
+    --primary: oklch(0.62 0.075 55);              /* #d97757 */
+    --primary-foreground: oklch(0.98 0.003 80);
+
+    /* Secondary — warm light gray */
+    --secondary: oklch(0.935 0.008 80);           /* #e8e6dc */
+    --secondary-foreground: oklch(0.25 0.008 60);
+
+    /* Muted — warm mid-gray */
+    --muted: oklch(0.955 0.006 80);
+    --muted-foreground: oklch(0.48 0.01 70);      /* #b0aea5 */
+
+    /* Accent — soft warm fill */
+    --accent: oklch(0.94 0.007 80);
+    --accent-foreground: oklch(0.22 0.007 60);
+
+    --destructive: oklch(0.58 0.18 25);
+    --border: oklch(0.91 0.008 80);               /* #e8e6dc */
+    --input: oklch(0.91 0.008 80);
+    --ring: oklch(0.62 0.075 55);
+
+    /* Charts — brand accents, muted */
+    --chart-1: oklch(0.62 0.075 55);              /* orange */
+    --chart-2: oklch(0.58 0.055 245);             /* blue #6a9bcc */
+    --chart-3: oklch(0.56 0.06 130);              /* green #788c5d */
+    --chart-4: oklch(0.72 0.06 80);               /* warm gold */
+    --chart-5: oklch(0.45 0.04 250);              /* deep slate blue */
+
     --radius: 0.625rem;
-    --sidebar: oklch(0.985 0 0);
-    --sidebar-foreground: oklch(0.145 0 0);
-    --sidebar-primary: oklch(0.61 0.11 222);
-    --sidebar-primary-foreground: oklch(0.98 0.02 201);
-    --sidebar-accent: oklch(0.97 0 0);
-    --sidebar-accent-foreground: oklch(0.205 0 0);
-    --sidebar-border: oklch(0.922 0 0);
-    --sidebar-ring: oklch(0.708 0 0);
+
+    /* Sidebar tokens */
+    --sidebar: oklch(0.965 0.005 80);
+    --sidebar-foreground: oklch(0.16 0.005 60);
+    --sidebar-primary: oklch(0.62 0.075 55);
+    --sidebar-primary-foreground: oklch(0.98 0.003 80);
+    --sidebar-accent: oklch(0.935 0.008 80);
+    --sidebar-accent-foreground: oklch(0.22 0.007 60);
+    --sidebar-border: oklch(0.91 0.008 80);
+    --sidebar-ring: oklch(0.62 0.075 55);
+
+    /* Semantic badge tones — muted, flat */
+    --tone-earthquake: oklch(0.62 0.075 55);
+    --tone-earthquake-bg: oklch(0.62 0.075 55 / 12%);
+    --tone-earthquake-fg: oklch(0.42 0.06 55);
+
+    --tone-eonet: oklch(0.72 0.06 80);
+    --tone-eonet-bg: oklch(0.72 0.06 80 / 12%);
+    --tone-eonet-fg: oklch(0.48 0.05 80);
+
+    --tone-airquality: oklch(0.56 0.06 130);
+    --tone-airquality-bg: oklch(0.56 0.06 130 / 12%);
+    --tone-airquality-fg: oklch(0.38 0.05 130);
+
+    --tone-tsunami: oklch(0.58 0.055 245);
+    --tone-tsunami-bg: oklch(0.58 0.055 245 / 12%);
+    --tone-tsunami-fg: oklch(0.40 0.045 245);
+
+    --tone-info: oklch(0.50 0.04 250);
+    --tone-info-bg: oklch(0.50 0.04 250 / 12%);
+    --tone-info-fg: oklch(0.35 0.035 250);
+
+    --tone-meta: oklch(0.55 0.015 70);
+    --tone-meta-bg: oklch(0.55 0.015 70 / 10%);
+    --tone-meta-fg: oklch(0.40 0.012 70);
+
+    --tone-warning: oklch(0.70 0.06 85);
+    --tone-warning-bg: oklch(0.70 0.06 85 / 12%);
+    --tone-warning-fg: oklch(0.45 0.05 85);
+
+    --tone-danger: oklch(0.58 0.14 25);
+    --tone-danger-bg: oklch(0.58 0.14 25 / 12%);
+    --tone-danger-fg: oklch(0.42 0.12 25);
 }
 
 .dark {
-    --background: oklch(0.145 0 0);
-    --foreground: oklch(0.985 0 0);
-    --card: oklch(0.205 0 0);
-    --card-foreground: oklch(0.985 0 0);
-    --popover: oklch(0.205 0 0);
-    --popover-foreground: oklch(0.985 0 0);
-    --primary: oklch(0.71 0.13 215);
-    --primary-foreground: oklch(0.30 0.05 230);
-    --secondary: oklch(0.274 0.006 286.033);
-    --secondary-foreground: oklch(0.985 0 0);
-    --muted: oklch(0.269 0 0);
-    --muted-foreground: oklch(0.708 0 0);
-    --accent: oklch(0.371 0 0);
-    --accent-foreground: oklch(0.985 0 0);
-    --destructive: oklch(0.704 0.191 22.216);
-    --border: oklch(1 0 0 / 10%);
-    --input: oklch(1 0 0 / 15%);
-    --ring: oklch(0.556 0 0);
-    --chart-1: oklch(0.87 0.12 207);
-    --chart-2: oklch(0.80 0.13 212);
-    --chart-3: oklch(0.71 0.13 215);
-    --chart-4: oklch(0.61 0.11 222);
-    --chart-5: oklch(0.52 0.09 223);
-    --sidebar: oklch(0.205 0 0);
-    --sidebar-foreground: oklch(0.985 0 0);
-    --sidebar-primary: oklch(0.80 0.13 212);
-    --sidebar-primary-foreground: oklch(0.30 0.05 230);
-    --sidebar-accent: oklch(0.269 0 0);
-    --sidebar-accent-foreground: oklch(0.985 0 0);
-    --sidebar-border: oklch(1 0 0 / 10%);
-    --sidebar-ring: oklch(0.556 0 0);
+    --background: oklch(0.155 0.005 60);          /* #141413 */
+    --foreground: oklch(0.965 0.005 80);          /* #faf9f5 */
+    --card: oklch(0.195 0.006 60);
+    --card-foreground: oklch(0.965 0.005 80);
+    --popover: oklch(0.195 0.006 60);
+    --popover-foreground: oklch(0.965 0.005 80);
+
+    /* Primary — slightly brighter orange for dark bg */
+    --primary: oklch(0.68 0.08 55);
+    --primary-foreground: oklch(0.16 0.005 60);
+
+    --secondary: oklch(0.24 0.007 60);
+    --secondary-foreground: oklch(0.965 0.005 80);
+
+    --muted: oklch(0.22 0.006 60);
+    --muted-foreground: oklch(0.62 0.01 70);
+
+    --accent: oklch(0.28 0.008 60);
+    --accent-foreground: oklch(0.965 0.005 80);
+
+    --destructive: oklch(0.65 0.18 25);
+    --border: oklch(1 0 0 / 8%);
+    --input: oklch(1 0 0 / 12%);
+    --ring: oklch(0.68 0.08 55);
+
+    --chart-1: oklch(0.68 0.08 55);
+    --chart-2: oklch(0.64 0.06 245);
+    --chart-3: oklch(0.60 0.065 130);
+    --chart-4: oklch(0.76 0.065 80);
+    --chart-5: oklch(0.50 0.045 250);
+
+    --sidebar: oklch(0.18 0.005 60);
+    --sidebar-foreground: oklch(0.965 0.005 80);
+    --sidebar-primary: oklch(0.68 0.08 55);
+    --sidebar-primary-foreground: oklch(0.16 0.005 60);
+    --sidebar-accent: oklch(0.24 0.007 60);
+    --sidebar-accent-foreground: oklch(0.965 0.005 80);
+    --sidebar-border: oklch(1 0 0 / 8%);
+    --sidebar-ring: oklch(0.68 0.08 55);
+
+    /* Semantic badge tones — dark overrides */
+    --tone-earthquake-bg: oklch(0.68 0.08 55 / 18%);
+    --tone-earthquake-fg: oklch(0.78 0.06 55);
+
+    --tone-eonet-bg: oklch(0.76 0.065 80 / 18%);
+    --tone-eonet-fg: oklch(0.80 0.05 80);
+
+    --tone-airquality-bg: oklch(0.60 0.065 130 / 18%);
+    --tone-airquality-fg: oklch(0.78 0.05 130);
+
+    --tone-tsunami-bg: oklch(0.64 0.06 245 / 18%);
+    --tone-tsunami-fg: oklch(0.78 0.05 245);
+
+    --tone-info-bg: oklch(0.56 0.045 250 / 18%);
+    --tone-info-fg: oklch(0.76 0.04 250);
+
+    --tone-meta-bg: oklch(0.55 0.015 70 / 14%);
+    --tone-meta-fg: oklch(0.72 0.012 70);
+
+    --tone-warning-bg: oklch(0.74 0.065 85 / 18%);
+    --tone-warning-fg: oklch(0.82 0.05 85);
+
+    --tone-danger-bg: oklch(0.64 0.15 25 / 18%);
+    --tone-danger-fg: oklch(0.80 0.12 25);
 }
 
 @theme inline {
@@ -84,6 +165,30 @@
     --color-sidebar-primary: var(--sidebar-primary);
     --color-sidebar-foreground: var(--sidebar-foreground);
     --color-sidebar: var(--sidebar);
+    --color-tone-earthquake: var(--tone-earthquake);
+    --color-tone-earthquake-bg: var(--tone-earthquake-bg);
+    --color-tone-earthquake-fg: var(--tone-earthquake-fg);
+    --color-tone-eonet: var(--tone-eonet);
+    --color-tone-eonet-bg: var(--tone-eonet-bg);
+    --color-tone-eonet-fg: var(--tone-eonet-fg);
+    --color-tone-airquality: var(--tone-airquality);
+    --color-tone-airquality-bg: var(--tone-airquality-bg);
+    --color-tone-airquality-fg: var(--tone-airquality-fg);
+    --color-tone-tsunami: var(--tone-tsunami);
+    --color-tone-tsunami-bg: var(--tone-tsunami-bg);
+    --color-tone-tsunami-fg: var(--tone-tsunami-fg);
+    --color-tone-info: var(--tone-info);
+    --color-tone-info-bg: var(--tone-info-bg);
+    --color-tone-info-fg: var(--tone-info-fg);
+    --color-tone-meta: var(--tone-meta);
+    --color-tone-meta-bg: var(--tone-meta-bg);
+    --color-tone-meta-fg: var(--tone-meta-fg);
+    --color-tone-warning: var(--tone-warning);
+    --color-tone-warning-bg: var(--tone-warning-bg);
+    --color-tone-warning-fg: var(--tone-warning-fg);
+    --color-tone-danger: var(--tone-danger);
+    --color-tone-danger-bg: var(--tone-danger-bg);
+    --color-tone-danger-fg: var(--tone-danger-fg);
     --color-chart-5: var(--chart-5);
     --color-chart-4: var(--chart-4);
     --color-chart-3: var(--chart-3);

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -548,13 +548,13 @@ export const UV_RISK_INFO: Record<UVRiskLevel, { label: string; color: string; d
 
 // Get magnitude color based on Richter scale
 export const getMagnitudeColor = (magnitude: number): string => {
-  if (magnitude < 2) return "#22c55e"; // green-500 - micro
-  if (magnitude < 4) return "#eab308"; // yellow-500 - minor
-  if (magnitude < 5) return "#f97316"; // orange-500 - light
-  if (magnitude < 6) return "#ef4444"; // red-500 - moderate
-  if (magnitude < 7) return "#dc2626"; // red-600 - strong
-  if (magnitude < 8) return "#b91c1c"; // red-700 - major
-  return "#7f1d1d"; // red-900 - great
+  if (magnitude < 2) return "#788c5d"; // sage green — micro
+  if (magnitude < 4) return "#c4a749"; // warm gold — minor
+  if (magnitude < 5) return "#d97757"; // muted orange — light
+  if (magnitude < 6) return "#c45c42"; // muted red-orange — moderate
+  if (magnitude < 7) return "#a84832"; // deep terra cotta — strong
+  if (magnitude < 8) return "#8b3a28"; // dark brown-red — major
+  return "#6b2d1f"; // deep umber — great
 };
 
 // Get magnitude label


### PR DESCRIPTION
## Description
Adopt the brand-guidelines warm, muted palette using oklch CSS variables, unify all color references through semantic tokens, simplify the settings/menu UX, compact the map details popover, and add tabs to the mobile drawer.

## Related Issue
N/A

## Type of Change
- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📝 Documentation update
- [x] 🎨 Style/UI update
- [ ] ♻️ Refactor (no functional changes)
- [ ] 🧪 Test update
- [ ] 🔧 Configuration change

## Changes Made
- Replaced all CSS custom properties in `index.css` with warm, muted oklch brand palette (light + dark mode)
- Added 8 semantic badge tone tokens (earthquake, eonet, airquality, tsunami, info, meta, warning, danger) with light/dark variants
- Updated `@theme inline` block with all new tone tokens for Tailwind class access
- Replaced ~30 hardcoded badge color strings across `global-activity.tsx`, `seismic-activity.tsx`, `hazr-earthquake-item.tsx` with semantic tokens
- Updated `MobileDrawerHeader` component and all 4 drawer call sites (Menu, Quakes, Global, Weather) to use semantic tokens
- Replaced `getMagnitudeColor` hex literals with brand-consistent muted tones (sage green → deep umber)
- Simplified settings panel from 3-tab layout to flat scrollable sections (Display, Data, Sources)
- Fixed `:root` pseudo-class syntax for proper CSS variable resolution under lightningcss
- Compacted map details popover: reduced tile size (80px → 56px), width (320px → 240px), and spacing
- Added shadcn/ui Separator between Map Type and Map Details sections
- Replaced Temperature Unit and Time Format Select with Tabs components
- Replaced OpenAQ Site Limit and NASA EONET Event Limit Sliders with Select components
- Added breathing space to mobile drawer header (pb-3 → pb-4) and content areas (pt-3)
- Added Tabs to mobile menu drawer separating Settings and About
- Dynamic drawer header that updates title, description, and icon based on active tab

## Screenshots/Recordings
| Before | After |
|--------|-------|
| Oversaturated Tailwind colors (orange-500, emerald-500, sky-500, etc.) | Warm, muted oklch brand palette |
| 3-tab settings panel | Flat scrollable sections |
| Bright drawer header badges (red, amber, sky) | Soft semantic tone badges |
| Large map details popover (320px) | Compact popover (240px) |
| Settings and About stacked in drawer | Tabbed interface with dynamic header |

## Testing
- [x] I have tested this locally
- [ ] I have added/updated unit tests
- [ ] I have added/updated integration tests

## Checklist
- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors
- [x] I have checked for accessibility compliance
- [x] I have verified responsive design (if applicable)

## Additional Notes
- All changes are purely visual — no functional behavior was modified
- The Outfit font and `--radius: 0.625rem` are retained as-is
- Map cluster colors in `openstreet-map.tsx` are outside scope and unchanged