### PR TITLE
feat(ui): sidebar badges, map markers, popup source links, and tsunami improvements

### DIFF
--- a/src/components/global-activity.tsx
+++ b/src/components/global-activity.tsx
@@ -353,7 +353,7 @@ const GlobalActivity = ({
     onClick: onTsunamiSelect ? () => onTsunamiSelect(alert) : undefined,
     badges: toSignalBadges([
       {
-        label: alert.severity,
+        label: `Tsunami ${alert.severity}`,
         icon: AlertTriangle,
         className: getTsunamiSeverityBadgeClass(alert.severity),
       },
@@ -451,7 +451,7 @@ const GlobalActivity = ({
               subDetail={
                 tsunamiState.isLoading || !highestTsunamiSeverity
                   ? undefined
-                  : `Highest severity: ${highestTsunamiSeverity}`
+                  : `Highest severity: Tsunami ${highestTsunamiSeverity}`
               }
             />
           ) : null}

--- a/src/components/global-activity.tsx
+++ b/src/components/global-activity.tsx
@@ -305,7 +305,7 @@ const GlobalActivity = ({
     const coordinateLabel = `${formatCoordinate(site.coordinates[1], "N", "S")} ${formatCoordinate(site.coordinates[0], "E", "W")}`;
     const locationLooksCoordinate = isCoordinateOnlyLabel(site.location);
     const friendlyTitle = locationLooksCoordinate
-      ? site.locationName?.trim() || locationHint || coordinateLabel
+      ? site.locationName?.trim() || locationHint || site.location
       : site.location;
     const subtitle = locationHint && locationHint !== friendlyTitle ? locationHint : undefined;
 

--- a/src/components/global-activity.tsx
+++ b/src/components/global-activity.tsx
@@ -190,6 +190,15 @@ const getTsunamiSeverityBadgeClass = (severity: string): string => {
   return "bg-tone-tsunami-bg text-tone-tsunami-fg";
 };
 
+const abbreviateTsunamiSeverity = (severity: string): string => {
+  switch (severity) {
+    case "Warning": return "Warn";
+    case "Information": return "Info";
+    case "Advisory": return "Advis";
+    default: return severity;
+  }
+};
+
 const formatTime = (date: Date): string => {
   return date.toLocaleTimeString("en-US", {
     hour: "numeric",
@@ -344,7 +353,7 @@ const GlobalActivity = ({
           : null,
       ]),
     };
-  });
+    });
 
   const tsunamiItems: SignalHistoryItem[] = tsunamiState.alerts.map((alert) => ({
     id: alert.id,
@@ -353,7 +362,7 @@ const GlobalActivity = ({
     onClick: onTsunamiSelect ? () => onTsunamiSelect(alert) : undefined,
     badges: toSignalBadges([
       {
-        label: `Tsunami ${alert.severity}`,
+        label: `Tsunami ${abbreviateTsunamiSeverity(alert.severity)}`,
         icon: AlertTriangle,
         className: getTsunamiSeverityBadgeClass(alert.severity),
       },

--- a/src/components/global-activity.tsx
+++ b/src/components/global-activity.tsx
@@ -178,11 +178,14 @@ const getTsunamiSeverityBadgeClass = (severity: string): string => {
   if (normalized.includes("extreme") || normalized.includes("severe")) {
     return "bg-tone-danger-bg text-tone-danger-fg";
   }
-  if (normalized.includes("major")) {
-    return "bg-tone-earthquake-bg text-tone-earthquake-fg";
+  if (normalized.includes("major") || normalized.includes("warning")) {
+    return "bg-tone-warning-bg text-tone-warning-fg";
   }
   if (normalized.includes("moderate")) {
-    return "bg-tone-warning-bg text-tone-warning-fg";
+    return "bg-tone-earthquake-bg text-tone-earthquake-fg";
+  }
+  if (normalized.includes("advisory")) {
+    return "bg-tone-eonet-bg text-tone-eonet-fg";
   }
   return "bg-tone-tsunami-bg text-tone-tsunami-fg";
 };
@@ -302,7 +305,7 @@ const GlobalActivity = ({
     const coordinateLabel = `${formatCoordinate(site.coordinates[1], "N", "S")} ${formatCoordinate(site.coordinates[0], "E", "W")}`;
     const locationLooksCoordinate = isCoordinateOnlyLabel(site.location);
     const friendlyTitle = locationLooksCoordinate
-      ? site.locationName?.trim() || locationHint || "OpenAQ station"
+      ? site.locationName?.trim() || locationHint || coordinateLabel
       : site.location;
     const subtitle = locationHint && locationHint !== friendlyTitle ? locationHint : undefined;
 
@@ -345,8 +348,7 @@ const GlobalActivity = ({
 
   const tsunamiItems: SignalHistoryItem[] = tsunamiState.alerts.map((alert) => ({
     id: alert.id,
-    title: alert.headline,
-    subtitle: "NWS tsunami bulletin",
+    title: alert.headline.replace(/^\[[^\]]+\]\s*/, ""),
     url: onTsunamiSelect ? undefined : alert.url,
     onClick: onTsunamiSelect ? () => onTsunamiSelect(alert) : undefined,
     badges: toSignalBadges([
@@ -362,10 +364,9 @@ const GlobalActivity = ({
           "bg-tone-info-bg text-tone-info-fg",
       },
       {
-        label: "NWS source",
-        icon: Waves,
-        className:
-          "bg-tone-tsunami-bg text-tone-tsunami-fg",
+        label: `${formatCoordinate(alert.coordinates[1], "N", "S")} ${formatCoordinate(alert.coordinates[0], "E", "W")}`,
+        icon: MapPin,
+        className: "bg-tone-meta-bg text-tone-meta-fg",
       },
     ]),
   }));

--- a/src/components/hazr-earthquake-item.tsx
+++ b/src/components/hazr-earthquake-item.tsx
@@ -117,6 +117,11 @@ const EarthquakeItem = ({
           ),
         }
       : null,
+    {
+      label: `${Math.abs(earthquake.coordinates[1]).toFixed(1)}°${earthquake.coordinates[1] >= 0 ? "N" : "S"} ${Math.abs(earthquake.coordinates[0]).toFixed(1)}°${earthquake.coordinates[0] >= 0 ? "E" : "W"}`,
+      icon: MapPin,
+      className: "bg-tone-meta-bg text-tone-meta-fg",
+    },
   ].filter(Boolean) as Array<{
     label: string;
     icon: React.ComponentType<{ className?: string }>;
@@ -149,10 +154,6 @@ const EarthquakeItem = ({
               </p>
               <ChevronRight className="size-4 shrink-0 text-muted-foreground/30 transition-transform group-hover:translate-x-0.5" />
             </div>
-          <div className="mt-1 flex items-center gap-1 text-xs font-medium text-muted-foreground/85">
-            <MapPin className="size-3.5" />
-            <span className="truncate">USGS event</span>
-          </div>
           <div className="mt-2 flex flex-wrap gap-1.5">
             {detailBadges.map((badge) => (
               <div

--- a/src/components/map/overlays/signal-overlay.tsx
+++ b/src/components/map/overlays/signal-overlay.tsx
@@ -633,6 +633,11 @@ export function SignalOverlay({
           onClose={onCloseEvent}
           badges={tsunamiBadges}
           details={tsunamiDetails}
+          footerAction={activeTsunami.url ? {
+            label: "View Source",
+            url: activeTsunami.url,
+            ariaLabel: "View NWS tsunami source",
+          } : undefined}
         />
       ) : null}
 

--- a/src/components/map/overlays/signal-overlay.tsx
+++ b/src/components/map/overlays/signal-overlay.tsx
@@ -619,6 +619,11 @@ export function SignalOverlay({
           onClose={onCloseEvent}
           badges={eventBadges}
           details={eventDetails}
+          footerAction={{
+            label: "View on NASA EONET",
+            url: activeEvent.url,
+            ariaLabel: "View EONET event details",
+          }}
         />
       ) : null}
 
@@ -652,6 +657,11 @@ export function SignalOverlay({
           onClose={onCloseEvent}
           badges={airQualityBadges}
           details={airQualityDetails}
+          footerAction={activeAirQuality.sourceUrl ? {
+            label: "View Source",
+            url: activeAirQuality.sourceUrl,
+            ariaLabel: "View OpenAQ source",
+          } : undefined}
         />
       ) : null}
     </div>,

--- a/src/components/openstreet-map.tsx
+++ b/src/components/openstreet-map.tsx
@@ -649,7 +649,7 @@ export default function GoogleMapsClone() {
                               <Waves className="size-3.5 text-blue-500" />
                             </span>
                             <span className="ml-1 max-w-24 overflow-hidden whitespace-nowrap opacity-100">
-                              {alert.severity}
+                              {`Tsunami ${alert.severity}`}
                             </span>
                           </div>
                         </button>

--- a/src/components/openstreet-map.tsx
+++ b/src/components/openstreet-map.tsx
@@ -364,6 +364,15 @@ export default function GoogleMapsClone() {
   const seismicDetailMinZoom = 8.4;
   const shouldRenderSeismicMarkers =
     layerVisibility.earthquakes && viewState.zoom >= seismicDetailMinZoom;
+  const eonetDetailMinZoom = 7;
+  const airQualityDetailMinZoom = 8;
+  const tsunamiDetailMinZoom = 6;
+  const shouldRenderEonetMarkers =
+    layerVisibility.eonet && viewState.zoom >= eonetDetailMinZoom;
+  const shouldRenderAirQualityMarkers =
+    layerVisibility.airQuality && viewState.zoom >= airQualityDetailMinZoom;
+  const shouldRenderTsunamiMarkers =
+    layerVisibility.tsunami && viewState.zoom >= tsunamiDetailMinZoom;
 
   const isDefaultCenter = React.useCallback((center: [number, number]) => {
     return (
@@ -553,6 +562,90 @@ export default function GoogleMapsClone() {
                     );
                   })}
 
+
+                {/* EONET Event Markers */}
+                {shouldRenderEonetMarkers &&
+                  eonetState.events.map((event) => (
+                    <MapMarker
+                      key={event.id}
+                      longitude={event.coordinates[0]}
+                      latitude={event.coordinates[1]}
+                    >
+                      <MarkerContent>
+                        <button
+                          type="button"
+                          onClick={() => handleEonetSelect(event)}
+                          className="relative flex items-center justify-center cursor-pointer"
+                          aria-label={`EONET event: ${event.title}`}
+                        >
+                          <div className="relative flex items-center rounded-full border border-white/15 px-1.5 py-1 text-[10px] font-bold text-white backdrop-blur transition-all duration-250 bg-amber-500">
+                            <span className="inline-flex size-5 items-center justify-center rounded-full bg-white/90">
+                              <Activity className="size-3.5 text-amber-500" />
+                            </span>
+                            <span className="ml-1 max-w-24 overflow-hidden whitespace-nowrap opacity-100">
+                              {event.category}
+                            </span>
+                          </div>
+                        </button>
+                      </MarkerContent>
+                    </MapMarker>
+                  ))}
+
+                {/* OpenAQ Site Markers */}
+                {shouldRenderAirQualityMarkers &&
+                  airQualityState.sites.map((site) => (
+                    <MapMarker
+                      key={site.id}
+                      longitude={site.coordinates[0]}
+                      latitude={site.coordinates[1]}
+                    >
+                      <MarkerContent>
+                        <button
+                          type="button"
+                          onClick={() => handleAirQualitySelect(site)}
+                          className="relative flex items-center justify-center cursor-pointer"
+                          aria-label={`OpenAQ: ${site.location}`}
+                        >
+                          <div className="relative flex items-center rounded-full border border-white/15 px-1.5 py-1 text-[10px] font-bold text-white backdrop-blur transition-all duration-250 bg-emerald-500">
+                            <span className="inline-flex size-5 items-center justify-center rounded-full bg-white/90">
+                              <Wind className="size-3.5 text-emerald-500" />
+                            </span>
+                            <span className="ml-1 max-w-24 overflow-hidden whitespace-nowrap opacity-100">
+                              {site.parameter.toUpperCase()} {Number.isFinite(site.value) ? site.value.toFixed(1) : site.value}{site.unit}
+                            </span>
+                          </div>
+                        </button>
+                      </MarkerContent>
+                    </MapMarker>
+                  ))}
+
+                {/* Tsunami Alert Markers */}
+                {shouldRenderTsunamiMarkers &&
+                  tsunamiState.alerts.map((alert) => (
+                    <MapMarker
+                      key={alert.id}
+                      longitude={alert.coordinates[0]}
+                      latitude={alert.coordinates[1]}
+                    >
+                      <MarkerContent>
+                        <button
+                          type="button"
+                          onClick={() => handleTsunamiSelect(alert)}
+                          className="relative flex items-center justify-center cursor-pointer"
+                          aria-label={`Tsunami: ${alert.headline}`}
+                        >
+                          <div className="relative flex items-center rounded-full border border-white/15 px-1.5 py-1 text-[10px] font-bold text-white backdrop-blur transition-all duration-250 bg-blue-500">
+                            <span className="inline-flex size-5 items-center justify-center rounded-full bg-white/90">
+                              <Waves className="size-3.5 text-blue-500" />
+                            </span>
+                            <span className="ml-1 max-w-24 overflow-hidden whitespace-nowrap opacity-100">
+                              {alert.severity}
+                            </span>
+                          </div>
+                        </button>
+                      </MarkerContent>
+                    </MapMarker>
+                  ))}
                 <MapClusterLayer
                   data={earthquakeGeojson}
                   visible={layerVisibility.earthquakes && viewState.zoom < seismicDetailMinZoom}

--- a/src/components/openstreet-map.tsx
+++ b/src/components/openstreet-map.tsx
@@ -374,6 +374,16 @@ export default function GoogleMapsClone() {
   const shouldRenderTsunamiMarkers =
     layerVisibility.tsunami && viewState.zoom >= tsunamiDetailMinZoom;
 
+  const isValidLngLat = React.useCallback((coords: [number, number]) => {
+    return (
+      Array.isArray(coords) &&
+      coords.length >= 2 &&
+      Number.isFinite(coords[0]) &&
+      Number.isFinite(coords[1]) &&
+      Math.abs(coords[1]) <= 90
+    );
+  }, []);
+
   const isDefaultCenter = React.useCallback((center: [number, number]) => {
     return (
       Math.abs(center[0] - DEFAULT_FALLBACK_CENTER[0]) < 0.01 &&
@@ -515,7 +525,7 @@ export default function GoogleMapsClone() {
 
                 {/* Earthquake Markers */}
                 {shouldRenderSeismicMarkers &&
-                  earthquakes.map((eq) => {
+                  earthquakes.filter((eq) => isValidLngLat(eq.coordinates)).map((eq) => {
                     const magnitudeColor = getMagnitudeColor(eq.magnitude);
                     const isActive = activeQuakePulseId === eq.id;
 
@@ -565,7 +575,7 @@ export default function GoogleMapsClone() {
 
                 {/* EONET Event Markers */}
                 {shouldRenderEonetMarkers &&
-                  eonetState.events.map((event) => (
+                  eonetState.events.filter((event) => isValidLngLat(event.coordinates)).map((event) => (
                     <MapMarker
                       key={event.id}
                       longitude={event.coordinates[0]}
@@ -593,7 +603,7 @@ export default function GoogleMapsClone() {
 
                 {/* OpenAQ Site Markers */}
                 {shouldRenderAirQualityMarkers &&
-                  airQualityState.sites.map((site) => (
+                  airQualityState.sites.filter((site) => isValidLngLat(site.coordinates)).map((site) => (
                     <MapMarker
                       key={site.id}
                       longitude={site.coordinates[0]}
@@ -621,7 +631,7 @@ export default function GoogleMapsClone() {
 
                 {/* Tsunami Alert Markers */}
                 {shouldRenderTsunamiMarkers &&
-                  tsunamiState.alerts.map((alert) => (
+                  tsunamiState.alerts.filter((alert) => isValidLngLat(alert.coordinates)).map((alert) => (
                     <MapMarker
                       key={alert.id}
                       longitude={alert.coordinates[0]}

--- a/src/components/openstreet-map.tsx
+++ b/src/components/openstreet-map.tsx
@@ -649,7 +649,7 @@ export default function GoogleMapsClone() {
                               <Waves className="size-3.5 text-blue-500" />
                             </span>
                             <span className="ml-1 max-w-24 overflow-hidden whitespace-nowrap opacity-100">
-                              {`Tsunami ${alert.severity}`}
+                              {`Tsunami ${{ Warning: "Warn", Information: "Info", Advisory: "Advis" }[alert.severity] ?? alert.severity}`}
                             </span>
                           </div>
                         </button>


### PR DESCRIPTION
## Description
Update sidebar badges with better location context, add individual map markers for EONET, OpenAQ, and Tsunami when zoomed in, improve tsunami alert display across the app, and add source links to all signal popups.

## Related Issue
N/A

## Type of Change
- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📝 Documentation update
- [x] 🎨 Style/UI update
- [ ] ♻️ Refactor (no functional changes)
- [ ] 🧪 Test update
- [ ] 🔧 Configuration change

## Changes Made
- OpenAQ sidebar: replaced "OpenAQ station" fallback with raw location data
- Earthquakes: removed "USGS event" subtitle, added coordinate badge (lat/lng)
- Tsunami sidebar: added coordinate badge with lat/lng
- Map markers: added individual MapMarker badges for EONET (amber, category label), OpenAQ (emerald, parameter value), and Tsunami (blue, severity) when zoomed in
- Added coordinate validation helper to prevent MapLibre crashes on bad data
- Tsunami map markers now show abbreviated severity (Tsunami Warn, Info, Advis)
- Tsunami popup: added "View Source" footer link to NWS bulletin
- Tsunami sidebar badges: abbreviated severity labels with Tsunami prefix
- EONET popup: added "View on NASA EONET" footer link
- OpenAQ popup: added "View Source" footer link (conditional on URL)

## Screenshots/Recordings
| Before | After |
|--------|-------|
| OpenAQ showed "OpenAQ station" | Shows actual location data |
| Earthquakes had "USGS event" subtitle | Shows coordinate badge instead |
| Tsunami lacked coordinate badge | Shows lat/lng coordinate badge |
| EONET/OpenAQ/Tsunami only had clusters on map | Individual map markers with icons when zoomed in |
| Tsunami popup had no source link | "View Source" button linking to NWS |
| EONET popup had no source link | "View on NASA EONET" button |
| OpenAQ popup had no source link | "View Source" button linking to OpenAQ |

## Testing
- [x] I have tested this locally
- [ ] I have added/updated unit tests
- [ ] I have added/updated integration tests

## Checklist
- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors
- [x] I have checked for accessibility compliance
- [x] I have verified responsive design (if applicable)

## Additional Notes
- Coordinate badges use the same formatting as existing EONET coordinate badges
- Map markers only appear above zoom thresholds (EONET: 7, OpenAQ: 8, Tsunami: 6) to avoid clutter
- Cluster layers still display at lower zoom levels
- All source links only show when URL is available