### PR TITLE
feat(sidebar): pin Settings and About in a collapsed-sidebar footer

### DIFF
--- a/src/components/hazr-menu-panel.tsx
+++ b/src/components/hazr-menu-panel.tsx
@@ -1,17 +1,10 @@
 "use client";
 
 import React from "react";
-import { Info, Settings2 } from "lucide-react";
 
 import { WeatherDock } from "@/components/map/weather-dock";
-import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from "@/components/ui/tooltip";
+import { TooltipProvider } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
 
 import type {
@@ -31,8 +24,6 @@ export type HazrMenuFocusTarget =
   | "global-tsunami";
 
 type HazrMenuPanelProps = {
-  onSettingsSelect?: () => void;
-  onAboutSelect?: () => void;
   collapsed?: boolean;
   focusTarget?: HazrMenuFocusTarget | null;
   onFocusTargetHandled?: () => void;
@@ -73,8 +64,6 @@ import { SeismicActivity } from "@/components/seismic-activity";
 import { GlobalActivity } from "@/components/global-activity";
 
 function HazrMenuPanel({
-  onSettingsSelect,
-  onAboutSelect,
   collapsed = false,
   focusTarget = null,
   onFocusTargetHandled,
@@ -150,9 +139,6 @@ function HazrMenuPanel({
       onFocusTargetHandled?.();
     }
   }, [collapsed, focusTarget, onFocusTargetHandled]);
-
-  const handleSettingsClick = () => onSettingsSelect?.();
-  const handleAboutClick = () => onAboutSelect?.();
 
   const shouldShowSeismic = layerVisibility.earthquakes;
   const shouldShowGlobalSignals =
@@ -263,67 +249,6 @@ function HazrMenuPanel({
           </>
         ) : null}
 
-        {shouldShowSeismic || shouldShowGlobalSignals ? (
-          <Separator className={cn(collapsed ? "my-2" : "my-2")} />
-        ) : null}
-        
-        {/* Settings */}
-        {collapsed ? (
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Button
-                variant="ghost"
-                size="icon-lg"
-                className="size-12 justify-center rounded-md px-0 text-muted-foreground hover:bg-muted/70"
-                onClick={handleSettingsClick}
-                aria-label="Settings"
-              >
-                <Settings2 className="size-5" />
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent side="right">Settings</TooltipContent>
-          </Tooltip>
-        ) : (
-          <Button
-            variant="ghost"
-            size="default"
-            className="w-full justify-start gap-3 rounded-md text-foreground/90 hover:bg-muted/70 hover:text-foreground"
-            onClick={handleSettingsClick}
-            aria-label="Settings"
-          >
-            <Settings2 className="size-4" />
-            <span className="truncate">Settings</span>
-          </Button>
-        )}
-
-        {/* About */}
-        {collapsed ? (
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Button
-                variant="ghost"
-                size="icon-lg"
-                className="mt-1 size-12 justify-center rounded-md px-0 text-muted-foreground hover:bg-muted/70"
-                onClick={handleAboutClick}
-                aria-label="About Hazr"
-              >
-                <Info className="size-5" />
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent side="right">About Hazr</TooltipContent>
-          </Tooltip>
-        ) : (
-          <Button
-            variant="ghost"
-            size="default"
-            className="mt-1 w-full justify-start gap-3 rounded-md text-foreground/90 hover:bg-muted/70 hover:text-foreground"
-            onClick={handleAboutClick}
-            aria-label="About Hazr"
-          >
-            <Info className="size-4" />
-            <span className="truncate">About</span>
-          </Button>
-        )}
       </div>
     </TooltipProvider>
   );

--- a/src/components/hazr-sidebar-footer.tsx
+++ b/src/components/hazr-sidebar-footer.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import { Info, Settings2 } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { cn } from "@/lib/utils";
+
+type HazrSidebarFooterProps = {
+  collapsed?: boolean;
+  onSettingsSelect?: () => void;
+  onAboutSelect?: () => void;
+};
+
+function HazrSidebarFooter({
+  collapsed = false,
+  onSettingsSelect,
+  onAboutSelect,
+}: HazrSidebarFooterProps) {
+  return (
+    <TooltipProvider delayDuration={0}>
+      <div className={cn("flex flex-col gap-1", collapsed && "items-center")}>
+        {/* Settings */}
+        {collapsed ? (
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant="ghost"
+                size="icon-lg"
+                className="size-12 justify-center rounded-md px-0 text-muted-foreground hover:bg-muted/70"
+                onClick={() => onSettingsSelect?.()}
+                aria-label="Settings"
+              >
+                <Settings2 className="size-5" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent side="right">Settings</TooltipContent>
+          </Tooltip>
+        ) : (
+          <Button
+            variant="ghost"
+            size="default"
+            className="w-full justify-start gap-3 rounded-md text-foreground/90 hover:bg-muted/70 hover:text-foreground"
+            onClick={() => onSettingsSelect?.()}
+            aria-label="Settings"
+          >
+            <Settings2 className="size-4" />
+            <span className="truncate">Settings</span>
+          </Button>
+        )}
+
+        {/* About */}
+        {collapsed ? (
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant="ghost"
+                size="icon-lg"
+                className="size-12 justify-center rounded-md px-0 text-muted-foreground hover:bg-muted/70"
+                onClick={() => onAboutSelect?.()}
+                aria-label="About Hazr"
+              >
+                <Info className="size-5" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent side="right">About Hazr</TooltipContent>
+          </Tooltip>
+        ) : (
+          <Button
+            variant="ghost"
+            size="default"
+            className="w-full justify-start gap-3 rounded-md text-foreground/90 hover:bg-muted/70 hover:text-foreground"
+            onClick={() => onAboutSelect?.()}
+            aria-label="About Hazr"
+          >
+            <Info className="size-4" />
+            <span className="truncate">About</span>
+          </Button>
+        )}
+      </div>
+    </TooltipProvider>
+  );
+}
+
+export { HazrSidebarFooter };

--- a/src/components/hazr-sidebar.tsx
+++ b/src/components/hazr-sidebar.tsx
@@ -14,10 +14,12 @@ import {
   HazrMenuPanel,
   type HazrMenuFocusTarget,
 } from "@/components/hazr-menu-panel"
+import { HazrSidebarFooter } from "@/components/hazr-sidebar-footer"
 import { Button } from "@/components/ui/button"
 import {
   Sidebar,
   SidebarContent,
+  SidebarFooter,
   SidebarHeader,
   SidebarTrigger,
   useSidebar,
@@ -187,8 +189,6 @@ function HazrSidebar({
 
       <SidebarContent className="overflow-y-auto scrollbar-hide">
         <HazrMenuPanel
-          onSettingsSelect={onSettingsSelect}
-          onAboutSelect={onAboutSelect}
           collapsed={!isOpen}
           focusTarget={focusTarget}
           onFocusTargetHandled={handleFocusTargetHandled}
@@ -207,6 +207,14 @@ function HazrSidebar({
           tsunamiState={tsunamiState}
         />
       </SidebarContent>
+
+      <SidebarFooter>
+        <HazrSidebarFooter
+          collapsed={!isOpen}
+          onSettingsSelect={onSettingsSelect}
+          onAboutSelect={onAboutSelect}
+        />
+      </SidebarFooter>
     </Sidebar>
   )
 }


### PR DESCRIPTION
## Description
Adds a persistent `SidebarFooter` to `HazrSidebar` so the **Settings** and **About** actions stay reachable when the sidebar is collapsed to its compact rail — no need to expand the sidebar or scroll to the bottom of the scrollable content first.

The new `HazrSidebarFooter` component (backed by the shadcn/ui `SidebarFooter` primitive, which was previously exported but unused) holds the Settings/About entries:
- **Expanded:** full-width labeled rows (`Settings2` / `Info` icons with text labels)
- **Collapsed:** icon-only buttons with right-side shadcn/ui tooltips

The entries were removed from `HazrMenuPanel`'s scrollable content, along with its now-unused `onSettingsSelect`/`onAboutSelect` props. `HazrSidebar` keeps the same callback wiring, so handler behavior (settings panel / about dialog) is unchanged.

## Related Issue
Fixes #33

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📝 Documentation update
- [x] 🎨 Style/UI update
- [ ] ♻️ Refactor (no functional changes)
- [ ] 🧪 Test update
- [ ] 🔧 Configuration change

## Changes Made

- Added `src/components/hazr-sidebar-footer.tsx` with the `HazrSidebarFooter` component (collapsed icon + tooltip / expanded labeled row variants)
- Wired `SidebarFooter` + `HazrSidebarFooter` into `HazrSidebar` below `SidebarContent`, passing `collapsed={!isOpen}` and the existing `onSettingsSelect`/`onAboutSelect` callbacks
- Removed the Settings/About block, its props, handlers, and trailing separator from `HazrMenuPanel` so app-level actions are no longer buried in the scrollable rail

## Screenshots/Recordings

N/A — visual styles are identical to the previous inline buttons, just relocated to the pinned footer.

## Testing

- [x] I have tested this locally
- [ ] I have added/updated unit tests
- [ ] I have added/updated integration tests

`bun run build` passes (tsc + vite).

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my code
- [ ] I have commented my code where necessary
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors
- [x] I have checked for accessibility compliance
- [ ] I have verified responsive design (if applicable)

## Additional Notes

- `SidebarFooter` primitive brings its own `border-t` and collapsed `px-2` padding, so the footer is visually separated from the scrollable content in both states.
- Keyboard accessibility is retained: both buttons are real `<Button>` elements with `aria-label`s in both states.